### PR TITLE
Build kube 1.5.6 and 1.6.2 images and update ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ sudo: required
 
 env:
   matrix:
-    - VERSION: kubernetes
+    - env:
+      - TRAVIS_KUBE_VERSION=v1.5.6
+      - TRAVIS_ETCD_VERSION=v3.0.14
+    - env:
+      - TRAVIS_KUBE_VERSION=v1.6.2
+      - TRAVIS_ETCD_VERSION=v3.0.17
 
 services:
   - docker

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -11,6 +11,8 @@ cd $ROOTDIR
 # build openwhisk images
 # This way everything that is teset will use the lates openwhisk builds
 
+sed -ie "s/whisk_config:v1.5.6/whisk_config:$TRAVIS_KUBE_VERSION/g" configure/configure_whisk.yml
+
 # run scripts to deploy using the new images.
 kubectl apply -f configure/openwhisk_kube_namespace.yml
 kubectl apply -f configure/configure_whisk.yml

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,28 +1,31 @@
 # This script assumes Docker is already installed
 #!/bin/bash
 
-TAG=v1.5.5
+set -x
 
 # set docker0 to promiscuous mode
 sudo ip link set docker0 promisc on
 
 # install etcd
-wget https://github.com/coreos/etcd/releases/download/v3.0.14/etcd-v3.0.14-linux-amd64.tar.gz
-tar xzf etcd-v3.0.14-linux-amd64.tar.gz
-sudo mv etcd-v3.0.14-linux-amd64/etcd /usr/local/bin/etcd
-rm etcd-v3.0.14-linux-amd64.tar.gz
-rm -rf etcd-v3.0.14-linux-amd64
+wget https://github.com/coreos/etcd/releases/download/$TRAVIS_ETCD_VERSION/etcd-$TRAVIS_ETCD_VERSION-linux-amd64.tar.gz
+tar xzf etcd-$TRAVIS_ETCD_VERSION-linux-amd64.tar.gz
+sudo mv etcd-$TRAVIS_ETCD_VERSION-linux-amd64/etcd /usr/local/bin/etcd
+rm etcd-$TRAVIS_ETCD_VERSION-linux-amd64.tar.gz
+rm -rf etcd-$TRAVIS_ETCD_VERSION-linux-amd64
 
 # download kubectl
-wget https://storage.googleapis.com/kubernetes-release/release/$TAG/bin/linux/amd64/kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/$TRAVIS_KUBE_VERSION/bin/linux/amd64/kubectl
 chmod +x kubectl
 sudo mv kubectl /usr/local/bin/kubectl
 
 # download kubernetes
 git clone https://github.com/kubernetes/kubernetes $HOME/kubernetes
 
+# install cfssl
+go get -u github.com/cloudflare/cfssl/cmd/...
+
 pushd $HOME/kubernetes
-  git checkout $TAG
+  git checkout $TRAVIS_KUBE_VERSION
   kubectl config set-credentials myself --username=admin --password=admin
   kubectl config set-context local --cluster=local --user=myself
   kubectl config set-cluster local --server=http://localhost:8080
@@ -36,7 +39,7 @@ popd
 
 # Wait untill kube is up and running
 TIMEOUT=0
-TIMEOUT_COUNT=30
+TIMEOUT_COUNT=40
 until $( curl --output /dev/null --silent http://localhost:8080 ) || [ $TIMEOUT -eq $TIMEOUT_COUNT ]; do
   echo "Kube is not up yet"
   let TIMEOUT=TIMEOUT+1
@@ -51,3 +54,7 @@ fi
 echo "Kubernetes is deployed and reachable"
 
 sudo chown -R $USER:$USER $HOME/.kube
+
+# Have seen issues where chown does not instantly change file permissions.
+# When this happens the build.sh cript can have failures.
+sleep 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:trusty
 ENV DEBIAN_FRONTEND noninteractive
 ENV UCF_FORCE_CONFFNEW YES
 RUN ucf --purge /boot/grub/menu.lst
+ARG KUBE_VERSION
 
 # install openwhisk
 RUN apt-get -y update && \
@@ -37,7 +38,6 @@ COPY configure /incubator-openwhisk-deploy-kube/configure
 COPY wsk /openwhisk/bin/wsk
 
 # install kube dependencies
-# Kubernetes assumes that the version is 1.5.0+
-RUN wget https://storage.googleapis.com/kubernetes-release/release/v1.5.0/bin/linux/amd64/kubectl && \
+RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/amd64/kubectl && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Because of the limitations mentioned above, all requirments to deploy OpenWhisk
 on Kubernetes need to be met.
 
 **Kubernetes**
-* Kubernetes version 1.5.0-1.5.5
+* Kubernetes version 1.5.6 and 1.6.2
   - https://github.com/kubernetes/kubernetes
 * Kubernetes has [KubeDNS](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/) deployed
 * (Optional) Kubernetes Pods can receive public addresses.
@@ -80,7 +80,18 @@ kubectl apply -f configure/openwhisk_kube_namespace.yml
 ```
 
 From here, you should just need to run the Kubernetes job to
-setup the OpenWhisk environment.
+setup the OpenWhisk environment. The only caveat is that
+the default image is used to deploy to kube v1.5.6.
+Take a look
+[here](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/configure/configure_whisk.yml#L19)
+if you wish to change to kube v1.6.2 by replacing `v1.5.2` to `v1.6.2`.
+
+**NOTE** Unfortunately Kube does not have backward compatibility
+requirements between the cli and Kube api server. However,
+the v1.5.6 image will probably work with any Kube v1.5+
+and the v1.6.2 image will probably work with any Kube v1.6+.
+If the configuration image does return compatibility
+issues then try [building a custom image](#manually-building-custom-docker-files).
 
 ```
 kubectl apply -f configure/configure_whisk.yml
@@ -139,7 +150,14 @@ wsk property set --auth $AUTH_SECRET --apihost https://[nginx_ip]:$WSK_PORT
 ## Manually Building Custom Docker Files
 
 There are two images that are required when deploying OpenWhisk on Kube,
-Nginx and the OpenWhisk configuration image.
+Nginx and the OpenWhisk configuration image. Right now the the configuration
+images built will work with a Kube version 1.5.6 and 1.6.2. To build the
+configuration image with a custom Kube version you can edit the build script
+[here](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/kube-1.6/docker/build.sh#L87-L88)
+
+Take a look
+[here](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/configure/configure_whisk.yml#L19)
+to view which images are buing used.
 
 To build these images, there is a helper script to build the
 required dependencies and build the docker images itself. For example,
@@ -227,7 +245,6 @@ ip link set docker0 promisc on
 
 ## Enhancements and TODOS
 
-* Deploy OpenWhisk on Kubernetes 1.6+
 * Allow users to provide custom certs for Nginx
 * Enable the configuration job to run any number of times. This way it updates an already running
   OpenWhisk deployment on all subsequent runs

--- a/configure/configure_whisk.yml
+++ b/configure/configure_whisk.yml
@@ -16,6 +16,6 @@ spec:
       restartPolicy: Never
       containers:
       - name: configure-openwhisk
-        image: danlavine/whisk_config:latest
+        image: danlavine/whisk_config:v1.5.6
         imagePullPolicy: Always
         command: [ "/incubator-openwhisk-deploy-kube/configure/configure.sh" ]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -69,15 +69,21 @@ pushd $SCRIPTDIR/nginx
  rm -rf blackbox
 popd
 
-# build the OpenWhisk deploy image
-pushd $SCRIPTDIR/..
- # copy whisk cli
- cp $OPENWHISK_DIR/bin/wsk .
+BuildKubeConfigureImage () {
+  pushd $SCRIPTDIR/..
+   # copy whisk cli
+   cp $OPENWHISK_DIR/bin/wsk .
 
- WHISK_DEPLOY_IMAGE=$(docker build . | grep "Successfully built" | awk '{print $3}')
- docker tag $WHISK_DEPLOY_IMAGE "$1"/whisk_config:dev
- docker push "$1"/whisk_config:dev
+   WHISK_DEPLOY_IMAGE=$(docker build --build-arg KUBE_VERSION="$2" . | grep "Successfully built" | awk '{print $3}')
+   docker tag $WHISK_DEPLOY_IMAGE "$1"/whisk_config:"$2"-dev
+   docker push "$1"/whisk_config:"$2"-dev
 
- # rm the whisk cli to keep things clean
- rm wsk
-popd
+   # rm the whisk cli to keep things clean
+   rm wsk
+  popd
+}
+
+# build the OpenWhisk configure image
+BuildKubeConfigureImage "$1" "v1.5.6"
+BuildKubeConfigureImage "$1" "v1.6.2"
+


### PR DESCRIPTION
* Create a kube 1.6.2 deployment image.
* Update CI to test both kube versions
* Update Docker scripts to build all images