### PR TITLE
Allow more time for Kafka to start

### DIFF
--- a/ansible-kube/roles/kafka/tasks/deploy.yml
+++ b/ansible-kube/roles/kafka/tasks/deploy.yml
@@ -41,7 +41,7 @@
   shell: "kubectl -n openwhisk logs {{ item[0] }} -c kafka"
   register: result
   until: ('[Kafka Server 0], started' in result.stdout)
-  retries: 10
+  retries: 36
   delay: 5
   with_nested:
     - ["{{ kafka_pods }}"]


### PR DESCRIPTION
Locally with a fresh environment (with no docker images downloaded) the
default loop count isn't enough to ensure that the kafka pod is fully
started. I have signed the Apache CLA as "Tobias Oliver Crawley".