### PR TITLE
Pin docker API version to support minikube

### DIFF
--- a/ansible-kube/environments/kube/files/invoker.yml
+++ b/ansible-kube/environments/kube/files/invoker.yml
@@ -53,6 +53,8 @@ spec:
             value: "2s"
           - name: "SERVICE_CHECK_INTERVAL"
             value: "15s"
+          - name: "DOCKER_API_VERSION"
+            value: "1.23"
         ports:
         - name: invoker
           containerPort: 8080


### PR DESCRIPTION
Minikube currently uses Docker 1.23, and Openwhisk uses a newer
client. But Openwhisk doesn't currently require anything that isn't
provided by 1.23, so pinning the API version to 1.23 allows Openwhisk to
be used with minikube.

I've signed the CLA as "Tobias Oliver Crawley".
