### PR TITLE
Allow specifying OpenWhisk dir in docker/build.sh

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -25,7 +25,6 @@ EndOfMessage
   OPENWHISK_DIR=$HOME/workspace/openwhisk
 else
   OPENWHISK_DIR="$2"
-exit 1
 fi
 
 


### PR DESCRIPTION
Previously, specifying an OpenWhisk directory when running
`docker/build.sh` would cause the script to silently exit 1. Now, a
directory may be specified when the script is run.

ICLA signed and submitted on 2017/06/01

Related-Issue: apache/incubator-openwhisk-deploy-kube#6
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>