### PR TITLE
Add script and instructions for using Minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ ways to setup a Dev/Test environmnet depending on your host OS. To mitigate that
 VirtualBox with a Ubuntu VM. For the full instructions on setting an environment up,
 take a look at these [instructions](/docs/setting_up_kube/README.md).
 
+We also have experimental support for
+[Minikube](https://github.com/kubernetes/minikube), see the
+[Minikube-specific install instructions](/minikube/README.md) for more details.
+
 # Configure OpenWhisk
 
 To configure OpenWhisk on Kubernetes, you will need to target a Kubernetes
@@ -254,10 +258,6 @@ Lastly, since OpenWhisk is configured/deployed via a Kubernetes Pod it requires
 the correct kubectl version to be built into `danlavine/whisk_config`. For now,
 there is only a version for Kube 1.5, and one can be built for 1.6, but there
 is no CI to test it against at the moment.
-
-**Minikube is not supported** at this time because it uses an old version
-of docker (1.11.x). See the the [Requirements](#requirements)
-section for more info.
 
 ## Enhancements
 

--- a/docs/setting_up_kube/README.md
+++ b/docs/setting_up_kube/README.md
@@ -76,5 +76,7 @@ can be deployed with [Callico](https://www.projectcalico.org/) for the
 By default kubeadm runs with KubeDNS already enabled, but please make sure
 to install Kubeadm for Kube version 1.5.
 
-**Minikube is not supported** at this time because it uses an old version
-of docker (1.11.x).
+[Minikube](https://github.com/kubernetes/minikube) support is
+experimental, see the
+[Minikube-specific install instructions](/minikube/README.md) for more
+details.

--- a/minikube/README.md
+++ b/minikube/README.md
@@ -1,0 +1,41 @@
+# Deploying OpenWhisk to Minikube
+
+**Note:** this is currently experimental, and the integration tests
+don't yet run against Minikube on CI. Minikube currently uses an old
+version of Docker (v1.11.x), so may not be fully compatible with
+OpenWhisk (see [Requirements](../README.md#requirements) for more
+info). These steps have only been manually tested with Minikube
+v0.19.1.
+
+
+# Installation
+
+1. Download and set up [Minikube](https://github.com/kubernetes/minikube)
+2. Start minikube with `minikube start`
+3. run `./deploy_minikube.sh`. This will configure Minikube for
+   OpenWhisk, run the standard Kubernetes OpenWhisk deployment, then
+   reconfigure the Invoker so it can properly talk to the Docker
+   daemon used by Minikube
+
+Once you've started the deploy script, you can follow along on the
+progress of the configuration task as noted in the
+[top-level README](../README.md#configure-openwhisk). 
+
+
+# The details
+
+There are currently two changes required in order for OpenWhisk to
+work on Minikube, both of which are performed by the deploy script:
+
+1. The `docker0` interface inside Minikube needs to be put into
+   promiscuous mode to allow Kafka to talk to ZooKeeper
+2. The Docker client used by the Invoker is newer than the Docker
+   daemon provided by Minikube, so we have to set an environment
+   variable (`DOCKER_API_VERSION`) in the environment for the
+   Invoker's container (via the StatefulSet template) to force it to
+   use an older version of the API protocol (1.23). We then need to
+   delete the existing Invoker pod that was started by the initial
+   deploy to force a new one to be created with the new environment.
+
+
+

--- a/minikube/ci/build.sh
+++ b/minikube/ci/build.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -ex
+
+SCRIPTDIR=$(cd $(dirname "$0") && pwd)
+ROOTDIR="$SCRIPTDIR/../"
+
+cd $ROOTDIR
+
+# TODO: need official repo
+# build openwhisk images
+# This way everything that is tested will use the latest openwhisk builds
+
+./deploy_minikube.sh
+
+sleep 5
+
+CONFIGURE_POD=$(kubectl get pods --all-namespaces -o wide | grep configure | awk '{print $2}')
+
+PASSED=false
+TIMEOUT=0
+until $PASSED || [ $TIMEOUT -eq 25 ]; do
+  KUBE_DEPLOY_STATUS=$(kubectl -n openwhisk get jobs | grep configure-openwhisk | awk '{print $3}')
+  if [ $KUBE_DEPLOY_STATUS -eq 1 ]; then
+    PASSED=true
+    break
+  fi
+
+  kubectl get pods --all-namespaces -o wide --show-all
+
+  let TIMEOUT=TIMEOUT+1
+  sleep 30
+done
+
+if [ "$PASSED" = false ]; then
+  kubectl -n openwhisk logs $CONFIGURE_POD
+  kubectl get jobs --all-namespaces -o wide --show-all
+  kubectl get pods --all-namespaces -o wide --show-all
+
+  echo "The job to configure OpenWhisk did not finish with an exit code of 1"
+  exit 1
+fi
+
+echo "The job to configure OpenWhisk finished successfully"
+
+# Don't try and perform wsk actions the second it finishes deploying.
+# The CI ocassionaly fails if you perform actions to quickly.
+sleep 30
+
+AUTH_SECRET=$(kubectl -n openwhisk get secret openwhisk-auth-tokens -o yaml | grep 'auth_whisk_system:' | awk '{print $2}' | base64 --decode)
+WSK_PORT=$(kubectl -n openwhisk describe service nginx | grep https-api | grep NodePort| awk '{print $3}' | cut -d'/' -f1)
+WSK_HOST=$(minikube ip)
+WSK_URL="https://$WSK_HOST:$WSK_PORT"
+
+# download the wsk cli from nginx
+wget --no-check-certificate $WSK_URL/cli/go/download/linux/amd64/wsk
+chmod +x wsk
+
+# setup the wsk cli
+./wsk property set --auth $AUTH_SECRET --apihost $WSK_URL
+
+# create wsk action
+cat > hello.js << EOL
+function main() {
+  return {payload: 'Hello world'};
+}
+EOL
+
+./wsk -i action create hello hello.js
+
+
+sleep 5
+
+# run the new hello world action
+RESULT=$(./wsk -i action invoke --blocking hello | grep "\"status\": \"success\"")
+
+if [ -z "$RESULT" ]; then
+  echo "FAILED! Could not invoked custom action"
+  exit 1
+fi
+
+echo "PASSED! Deployed openwhisk and invoked custom action"
+
+# push the images to an official repo

--- a/minikube/ci/setup.sh
+++ b/minikube/ci/setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Installs and starts minikube
+
+set -x
+
+# download kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/v1.5.4/bin/linux/amd64/kubectl
+chmod +x kubectl
+sudo mv kubectl /usr/local/bin/kubectl
+
+# download minikube
+wget https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+chmod +x minikube-linux-amd64
+sudo mv minikube-linux-amd64 /usr/local/bin/minikube
+minikube version
+
+# assumes virtualbox, override with  --vm-driver virtualbox|kvm|xhyve|vmwarefusion
+minikube start
+
+# Wait until minikube is up and running
+TIMEOUT=0
+TIMEOUT_COUNT=40
+until $(minikube status &> /dev/null) || [ $TIMEOUT -eq $TIMEOUT_COUNT ]; do
+  echo "Minikube is not up yet"
+  let TIMEOUT=TIMEOUT+1
+  sleep 20
+done
+
+if [ $TIMEOUT -eq $TIMEOUT_COUNT ]; then
+  echo "Minikube is not up and running"
+  exit 1
+fi
+
+echo "Minikube is ready"
+
+
+

--- a/minikube/deploy_minikube.sh
+++ b/minikube/deploy_minikube.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+DIR=$( cd "$( dirname "$0" )" && pwd )
+
+echo "Enabling promisc mode in minikube"
+minikube ssh sudo ip link set docker0 promisc on
+
+echo "Launching configure job"
+kubectl apply -f $DIR/../configure/openwhisk_kube_namespace.yml
+kubectl apply -f $DIR/../configure/configure_whisk.yml
+
+
+printf "Waiting for invoker StatefulSet to exist"
+TIMEOUT=0
+TIMEOUT_COUNT=100
+until $(kubectl -n openwhisk get statefulset invoker &> /dev/null) || [ $TIMEOUT -eq $TIMEOUT_COUNT ]; do
+    printf "."
+    let TIMEOUT=TIMEOUT+1
+    sleep 5
+done
+echo
+
+if [ $TIMEOUT -eq $TIMEOUT_COUNT ]; then
+  echo "Gave up waiting for the invoker StatefulSet"
+  exit 1
+fi
+
+echo "Patching the invoker StatefulSet to downgrade the docker API version"
+kubectl -n openwhisk patch statefulset invoker --type=json -p '[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "DOCKER_API_VERSION", "value": "1.23"}}]'
+
+echo "Deleting existing invoker pod so it will get recreated with new env"
+kubectl -n openwhisk delete po/invoker-0
+
+CONFIGURE_POD=$(kubectl get pods --all-namespaces -o wide | grep configure | awk '{print $2}')
+
+printf "Waiting for the configure job to complete"
+PASSED=false
+TIMEOUT=0
+TIMEOUT_COUNT=25
+until $PASSED || [ $TIMEOUT -eq $TIMEOUT_COUNT ]; do
+  KUBE_DEPLOY_STATUS=$(kubectl -n openwhisk get jobs | grep configure-openwhisk | awk '{print $3}')
+  if [ $KUBE_DEPLOY_STATUS -eq 1 ]; then
+    PASSED=true
+    break
+  fi
+  printf "."
+  let TIMEOUT=TIMEOUT+1
+  sleep 30
+done
+echo
+
+if [ "$PASSED" = false ]; then
+  echo "The job to configure OpenWhisk did not finish successfully"
+  echo "Execute \`kubectl -n openwhisk logs $CONFIGURE_POD\` to see the output from the configure job"
+  exit 1
+fi
+
+port=$(kubectl -n openwhisk describe service nginx | grep https-api | grep NodePort | awk '{print $3}' | cut -d'/' -f1)
+url="https://$(minikube ip):$port"
+
+echo "OpenWhisk should now be available at $url"


### PR DESCRIPTION
This adds adds experimental support for supporting Minikube. It includes a script that configures Minikube's `docker0` interface, starts the configure job, and uses kube's patch functionality to modify the environment for the invoker StatefulSet to downgrade the Docker client's API version to work with the older Docker daemon in Minikube.

This also includes a pair of scripts in `ci/` (modeled after the existing scripts in `/.travis`) that can be used as the basis of a CI setup if CI is run on a platform that allows Minikube to create VMs. 

Without #4, the `deploy_minikube.sh` script fails on the first run on a new Minikube install due to a timeout waiting for Kafka to start, but succeeds on a second run (after calling `/configure/cleanup.sh`). Once #4 is merged, this should work more reliably on a fresh install.

Let me know if you need anything else here or have any questions.