### PR TITLE
Add config_root_dir to kube environment

### DIFF
--- a/ansible-kube/environments/kube/group_vars/all
+++ b/ansible-kube/environments/kube/group_vars/all
@@ -2,6 +2,7 @@
 # general properties
 kube_pod_dir: "{{ playbook_dir }}/environments/kube/files"
 whisk_version_name: kube
+config_root_dir: /tmp
 whisk_logs_dir: /tmp/wsklogs
 
 # docker properties


### PR DESCRIPTION
Previously, ansible-kube/environments/kube/group_vars/all did not
include a definition for `config_root_dir`, which caused ansible
failures on `gen untrusted certificate for host` in
apache/incubator-openwhisk/ansible/setup.yml.

Now, `config_root_dir` is being set to `/tmp`, which is the default from
apache/incubator-openwhisk.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>