### PR TITLE
WIP: configure/deploy via helm charts

### DIFF
--- a/charts/controller/.helmignore
+++ b/charts/controller/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: controller
+version: 0.1.0

--- a/charts/controller/templates/NOTES.txt
+++ b/charts/controller/templates/NOTES.txt
@@ -1,0 +1,4 @@
+1. Get the application URL by running these commands:
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}

--- a/charts/controller/templates/_helpers.tpl
+++ b/charts/controller/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/controller/templates/config.yaml
+++ b/charts/controller/templates/config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+data:
+  whisk.version.name: "{{ .Values.versionName }}"
+  whisk.version.date: "{{ .Values.versionDate }}"
+  whisk.version.buildno: "{{ .Values.image.tag }}"
+  java.opts: "-Xmx{{ .Values.controller.jvm.heap }}"
+  controller.opts: "{{ .Values.controller.arguments }}"

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/bash", "-c", "/controller/bin/controller 0"]
+          ports:
+            - name: controller
+              containerPort: {{ .Values.service.internalPort }}
+          env:
+            - name: "COMPONENT_NAME"
+              value: "controller"
+            - name: "CONSULSERVER_HOST"
+              value: "consul.openwhisk"
+            - name: "CONSUL_HOST_PORT4"
+              value: "8500"
+            - name: "KAFKA_NUMPARTITIONS"
+              value: "2"
+            - name: "SERVICE_CHECK_HTTP"
+              value: "/ping"
+            - name: "SERVICE_CHECK_TIMEOUT"
+              value: "2s"
+            - name: "SERVICE_CHECK_INTERVAL"
+              value: "15s"
+            - name: "PORT"
+              value: "{{ .Values.service.internalPort }}"
+            - name: "WHISK_VERSION_NAME"
+              valueFrom:
+                configMapKeyRef:
+                  name: controller
+                  key: whisk.version.name
+            - name: "WHISK_VERSION_DATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: controller
+                  key: whisk.version.date
+            - name: "WHISK_VERSION_BUILDNO"
+              valueFrom:
+                configMapKeyRef:
+                  name: controller
+                  key: whisk.version.buildno
+            - name: "JAVA_OPTS"
+              valueFrom:
+                configMapKeyRef:
+                  name: controller
+                  key: java.opts
+            - name: "CONTROLLER_OPTS"
+              valueFrom:
+                configMapKeyRef:
+                  name: controller
+                  key: controller.opts
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.service.internalPort }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/charts/controller/templates/service.yaml
+++ b/charts/controller/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -1,0 +1,31 @@
+# Default values for controller.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+namespace: openwhisk
+versionName: kubernetes
+versionDate: "2017-07-21"
+image:
+  repository: openwhisk/controller
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  name: controller
+  type: ClusterIP
+  externalPort: 8080
+  internalPort: 8080
+controller:
+  jvm:
+    heap: "2g"
+  arguments: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098"
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  #requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/charts/nginx/.helmignore
+++ b/charts/nginx/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: nginx
+version: 0.1.0

--- a/charts/nginx/init/nginx/Dockerfile
+++ b/charts/nginx/init/nginx/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y curl
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+	chmod +x kubectl && \
+	mv kubectl /usr/local/bin/kubectl
+
+ADD certs.sh /usr/local/bin/certs.sh
+RUN chmod +x /usr/local/bin/certs.sh
+

--- a/charts/nginx/init/nginx/certs.sh
+++ b/charts/nginx/init/nginx/certs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+if [ -z "$1" ]; then
+cat <<- EndOfMessage
+  First argument should be the domain for the OpenWhisk deployment.
+  Note: By default the Nginx config file assumes the pattern '*.openwhisk'.
+EndOfMessage
+
+exit 1
+fi
+
+mkdir -p certs
+
+openssl req -x509 -newkey rsa:2048 -keyout certs/key.pem -out certs/cert.pem -nodes -subj "/CN=$1" -days 365

--- a/charts/nginx/nginx-service.yaml
+++ b/charts/nginx/nginx-service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  namespace: openwhisk
+  name: nginx-service
+  labels:
+    name: nginx
+spec:
+  type: NodePort
+  selector:
+    name: nginx
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 443

--- a/charts/nginx/templates/NOTES.txt
+++ b/charts/nginx/templates/NOTES.txt
@@ -1,0 +1,5 @@
+1. Get the application URL by running these commands:
+export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+echo http://$NODE_IP:$NODE_PORT
+

--- a/charts/nginx/templates/_helpers.tpl
+++ b/charts/nginx/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/nginx/templates/config.yaml
+++ b/charts/nginx/templates/config.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: openwhisk
+data:
+  nginx.conf: |
+    events {
+        worker_connections  4096;
+    }
+
+    http {
+        client_max_body_size 50M;
+
+        rewrite_log on;
+        log_format combined-upstream '$remote_addr - $remote_user [$time_local] '
+            '$request $status $body_bytes_sent '
+            '$http_referer $http_user_agent $upstream_addr';
+        access_log /logs/nginx_access.log combined-upstream;
+
+        upstream controllers {
+            server controller.openwhisk:8080 fail_timeout=60s;
+
+            # TODO: Remove the above controller setup and remove the commented
+            # lines below once the Controller has ben converted to a pure yaml
+            # configuration.
+            #
+            # server controller-0.openwhisk:8080 fail_timeout=60s;
+            # server controller-1.openwhisk:8080 backup;
+        }
+
+        server {
+            listen 443 default ssl;
+
+            # match namespace, note while OpenWhisk allows a richer character set for a
+            # namespace, not all those characters are permitted in the (sub)domain name;
+            # if namespace does not match, no vanity URL rewriting takes place.
+            server_name ~^(?<namespace>[0-9a-zA-Z-]+)\.{{ .Values.nginx.domainName }}$;
+
+            ssl_session_cache    shared:SSL:1m;
+            ssl_session_timeout  10m;
+            ssl_certificate      /etc/nginx/certs/tls.crt;
+            ssl_certificate_key  /etc/nginx/certs/tls.key;
+            ssl_verify_client off;
+            ssl_protocols        TLSv1 TLSv1.1 TLSv1.2;
+            ssl_ciphers RC4:HIGH:!aNULL:!MD5;
+            ssl_prefer_server_ciphers on;
+            proxy_ssl_session_reuse off;
+
+            # proxy to the web action path
+            location / {
+                if ($namespace) {
+                  rewrite    /(.*) /api/v1/web/${namespace}/$1 break;
+                }
+                proxy_pass http://controllers;
+                proxy_read_timeout 70s; # 60+10 additional seconds to allow controller to terminate request
+            }
+
+            # proxy to 'public/html' web action by convention
+            location = / {
+                if ($namespace) {
+                  rewrite    ^ /api/v1/web/${namespace}/public/index.html break;
+                }
+                proxy_pass http://controllers;
+                proxy_read_timeout 70s; # 60+10 additional seconds to allow controller to terminate request
+            }
+
+            location /blackbox-0.1.0.tar.gz {
+                root /etc/nginx;
+            }
+
+            location /OpenWhiskIOSStarterApp.zip {
+                return 301 https://github.com/openwhisk/openwhisk-client-swift/releases/download/0.2.3/starterapp-0.2.3.zip;
+            }
+
+            location /cli/go/download {
+                autoindex on;
+                root /etc/nginx;
+            }
+        }
+    }

--- a/charts/nginx/templates/deployment.yaml
+++ b/charts/nginx/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: openwhisk
+  labels:
+    name: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    pod.beta.kubernetes.io/init-containers: '[
+        {
+            "name": "init-nginx",
+            "image": "berndtj/init-nginx",
+            "command": ["sh", "-c", "certs.sh {{ .Values.domainName }} && (kubectl create secret tls nginx --cert=certs/cert.pem --key=certs/key.pem || true)"]
+        }
+    ]'
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        name: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      restartPolicy: Always
+      volumes:
+      - name: nginx-certs
+        secret:
+          secretName: nginx
+      - name: nginx-conf
+        configMap:
+          name: nginx
+      - name: logs
+        emptyDir: {}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.ports.http.internalPort }}
+              name: http
+            - containerPort: {{ .Values.service.ports.httpsApi.internalPort }}
+              name: https-api
+            - containerPort: {{ .Values.service.ports.httpsAdmin.internalPort }}
+              name: https-admin
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.service.ports.httpsApi.internalPort }}
+            initialDelaySeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.service.ports.httpsApi.internalPort }}
+            initialDelaySeconds: 5
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+          volumeMounts:
+          - name: nginx-conf
+            mountPath: "/etc/nginx/nginx.conf"
+            subPath: "nginx.conf"
+          - name: nginx-certs
+            mountPath: "/etc/nginx/certs"
+          - name: logs
+            mountPath: "/logs"

--- a/charts/nginx/templates/service.yaml
+++ b/charts/nginx/templates/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: openwhisk
+  labels:
+    name: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: NodePort
+  selector:
+    name: {{ template "name" . }}
+    release: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.service.ports.http.internalPort }}
+      targetPort: {{ .Values.service.ports.http.externalPort }}
+      name: http
+    - port: {{ .Values.service.ports.httpsApi.internalPort }}
+      targetPort: {{ .Values.service.ports.httpsApi.externalPort }}
+      name: https-api
+    - port: {{ .Values.service.ports.httpsAdmin.internalPort }}
+      targetPort: {{ .Values.service.ports.httpsAdmin.externalPort }}
+      name: https-admin

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -1,0 +1,47 @@
+# Default values for nginx.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+nginx:
+  domainName: localhost
+image:
+  repository: nginx
+  tag: stable
+  pullPolicy: IfNotPresent
+service:
+  name: nginx
+  type: NodePort
+  ports:
+    http:
+      externalPort: 80
+      internalPort: 80
+    httpsApi:
+      externalPort: 443
+      internalPort: 443
+    httpsAdmin:
+      externalPort: 8443
+      internalPort: 8443
+ingress:
+  enabled: false
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - chart-example.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  #requests:
+  #  cpu: 100m
+  #  memory: 128Mi


### PR DESCRIPTION
This commit is an example of using charts to deploy each
openwhisk component via charts instead of managing with ansible.

Taken a little bit further the entire application could be
deployable using a single chart (which references other charts).
All of the logic in the ansible scripts can be constructed with
kubernetes and helm functionality.

For instance deploying nginx is now:

	helm install --name demo --set nginx.domainName=localhost charts/nginx

The certs are generated by an init container automatically.

This is a WIP.  I wanted to open it up for review/comments.