### PR TITLE
use public images for invoker and controller

### DIFF
--- a/kubernetes/controller/controller.yml
+++ b/kubernetes/controller/controller.yml
@@ -37,7 +37,7 @@ spec:
         imagePullPolicy: Always
         # Update this image to the publix OpenWhisk Image once this PR is merged.
         # https://github.com/apache/incubator-openwhisk/pull/2452
-        image: danlavine/whisk_controller
+        image: openwhisk/controller
         command: ["/bin/bash", "-c", "COMPONENT_NAME=$(hostname | cut -d'-' -f2) /controller/bin/controller `hostname | cut -d'-' -f2`"]
         ports:
         - name: controller
@@ -80,6 +80,8 @@ spec:
           value: "9092"
 
         # specific controller arguments
+        - name: "CONTROLLER_INSTANCES"
+          value: "2"
         - name: "CONTROLLER_OPTS"
           value: ""
         - name: "DEFAULTLIMITS_ACTIONS_INVOKES_PERMINUTE"
@@ -92,6 +94,17 @@ spec:
           value: "50"
         - name: "DEFAULTLIMITS_TRIGGERS_FIRES_PERMINUTE"
           value: "60"
+        - name: "LIMITS_ACTIONS_SEQUENCE_MAXLENGTH"
+          value: "50"
+        - name: "LIMITS_TRIGGERS_FIRES_PERMINUTE"
+          value: "60"
+        - name: "LIMITS_ACTIONS_INVOKES_PERMINUTE"
+          value: "60"
+        - name: "LIMITS_ACTIONS_INVOKES_CONCURRENTINSYSTEM"
+          value: "5000"
+        - name: "LIMITS_ACTIONS_INVOKES_CONCURRENT"
+          value: "30"
+
 
         # properties for DB connection
         - name: "DB_USERNAME"

--- a/kubernetes/invoker/invoker.yml
+++ b/kubernetes/invoker/invoker.yml
@@ -39,7 +39,7 @@ spec:
         # TODO: change this to the public openwhisk image for nuking Consul.
         # there is a PR that needs to be merged first.
         # https://github.com/apache/incubator-openwhisk/pull/2452
-        image: danlavine/whisk_invoker
+        image: openwhisk/invoker
         command: [ "/bin/bash", "-c", "COMPONENT_NAME=$(hostname | cut -d'-' -f2) /invoker/bin/invoker `hostname | cut -d'-' -f2`" ]
         env:
           - name: "PORT"


### PR DESCRIPTION
This PR uses public Invoker and Controller images and it is able to create the required Kafka topics because Kafka will auto create them if they do not exist. however, it does not create the Kafka topics with all the additional parameters Ansible is able to do. For that work, we would need this [PR](https://github.com/apache/incubator-openwhisk/pull/2545) to be merged.