### PR TITLE
Change invoker and controller to using public openwhisk image

### DIFF
--- a/kubernetes/controller/README.md
+++ b/kubernetes/controller/README.md
@@ -22,6 +22,7 @@ you will need to update a number of properties, for Kafka and Nginx.
 
 * Controller: You will need to update the replication count for the
   Controllers [here](https://github.com/apache/incubator-openwhisk-deploy-kube/tree/master/kubernetes/controller/controller.yml#L10)
+  and the value of CONTROLLER_INSTANCES [here](https://github.com/apache/incubator-openwhisk-deploy-kube/tree/master/kubernetes/controller/controller.yml#L84)
   and redeploy.
 
 * Nginx: Take a look at the Nginx [README](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/kubernetes/nginx/README.md#increase-controller-count)

--- a/kubernetes/controller/controller.yml
+++ b/kubernetes/controller/controller.yml
@@ -35,9 +35,7 @@ spec:
       containers:
       - name: controller
         imagePullPolicy: Always
-        # Update this image to the publix OpenWhisk Image once this PR is merged.
-        # https://github.com/apache/incubator-openwhisk/pull/2452
-        image: danlavine/whisk_controller
+        image: openwhisk/controller
         command: ["/bin/bash", "-c", "COMPONENT_NAME=$(hostname | cut -d'-' -f2) /controller/bin/controller `hostname | cut -d'-' -f2`"]
         ports:
         - name: controller
@@ -82,15 +80,17 @@ spec:
         # specific controller arguments
         - name: "CONTROLLER_OPTS"
           value: ""
-        - name: "DEFAULTLIMITS_ACTIONS_INVOKES_PERMINUTE"
+        - name: "CONTROLLER_INSTANCES"
+          value: "2"
+        - name: "LIMITS_ACTIONS_INVOKES_PERMINUTE"
           value: "120"
-        - name: "DEFAULTLIMITS_ACTIONS_INVOKES_CONCURRENT"
+        - name: "LIMITS_ACTIONS_INVOKES_CONCURRENT"
           value: "100"
-        - name: "DEFAULTLIMITS_ACTIONS_INVOKES_CONCURRENTINSYSTEM"
+        - name: "LIMITS_ACTIONS_INVOKES_CONCURRENTINSYSTEM"
           value: "500"
-        - name: "DEFAULTLIMITS_ACTIONS_SEQUENCE_MAXLENGTH"
+        - name: "LIMITS_ACTIONS_SEQUENCE_MAXLENGTH"
           value: "50"
-        - name: "DEFAULTLIMITS_TRIGGERS_FIRES_PERMINUTE"
+        - name: "LIMITS_TRIGGERS_FIRES_PERMINUTE"
           value: "60"
 
         # properties for DB connection

--- a/kubernetes/invoker/invoker.yml
+++ b/kubernetes/invoker/invoker.yml
@@ -36,10 +36,7 @@ spec:
       containers:
       - name: invoker
         imagePullPolicy: Always
-        # TODO: change this to the public openwhisk image for nuking Consul.
-        # there is a PR that needs to be merged first.
-        # https://github.com/apache/incubator-openwhisk/pull/2452
-        image: danlavine/whisk_invoker
+        image: openwhisk/invoker
         command: [ "/bin/bash", "-c", "COMPONENT_NAME=$(hostname | cut -d'-' -f2) /invoker/bin/invoker `hostname | cut -d'-' -f2`" ]
         env:
           - name: "PORT"


### PR DESCRIPTION
Consul has been removed upstream; we can use the openwhisk images now.
Update required environment variables for controller to match requirements
of latest openwhisk image.