### PR TITLE
add default setting for CONTROLLER_BLACKBOXFRACTION

### DIFF
--- a/kubernetes/controller/controller.yml
+++ b/kubernetes/controller/controller.yml
@@ -54,10 +54,6 @@ spec:
         - name: "PORT"
           value: "8080"
 
-        # Default blackbox fraction setting
-        - name: "CONTROLLER_BLACKBOXFRACTION"
-          value: "0.10"
-
         # Loadbalancer options
         - name: "LOADBALANCER_INVOKERBUSYTHRESHOLD"
           value: "16"
@@ -108,6 +104,8 @@ spec:
           value: "5000"
         - name: "LIMITS_ACTIONS_INVOKES_CONCURRENT"
           value: "30"
+        - name: "CONTROLLER_BLACKBOXFRACTION"
+          value: "0.10"
 
 
         # properties for DB connection

--- a/kubernetes/controller/controller.yml
+++ b/kubernetes/controller/controller.yml
@@ -54,6 +54,10 @@ spec:
         - name: "PORT"
           value: "8080"
 
+        # Default blackbox fraction setting
+        - name: "CONTROLLER_BLACKBOXFRACTION"
+          value: "0.10"
+
         # Loadbalancer options
         - name: "LOADBALANCER_INVOKERBUSYTHRESHOLD"
           value: "16"


### PR DESCRIPTION
When deploying the controller stateful set to the k8s cluster it was causing a crash and looking at the logs of the pods I found the following:

> [2017-09-20T18:32:04.756Z] [ERROR] [??] [Config] required property controller.blackboxFraction still not set                                     
[2017-09-20T18:32:04.758Z] [ERROR] [??] [Controller] Bad configuration, cannot start.  

Looking through source it appears a consistent default for `CONTROLLER_BLACKBOXFRACTION` is `0.10`. Adding this to the deployment manifest seems to have fixed the problem.