### PR TITLE
Fix Travis env variables after .travis.yml simplification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 sudo: required
 
 env:
-  matrix:
-    - env:
-      - TRAVIS_KUBE_VERSION=v1.6.2
-      - TRAVIS_ETCD_VERSION=v3.0.17
+  - TRAVIS_KUBE_VERSION=v1.6.2
+  - TRAVIS_ETCD_VERSION=v3.0.17
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: required
 
 env:
-  - TRAVIS_KUBE_VERSION=v1.6.2
-  - TRAVIS_ETCD_VERSION=v3.0.17
+  global:
+    - TRAVIS_KUBE_VERSION=v1.6.2
+    - TRAVIS_ETCD_VERSION=v3.0.17
 
 services:
   - docker


### PR DESCRIPTION
The syntax here was technically incorrect but did happen to work for
some time. However, recent Travis builds have failed because
TRAVIS_KUBE_VERSION is not defined and thus `kubectl` never gets
downloaded nor Kubernetes started.