### PR TITLE
Create the required CouchDB system databases

### DIFF
--- a/kubernetes/couchdb/docker/init.sh
+++ b/kubernetes/couchdb/docker/init.sh
@@ -57,6 +57,11 @@ pushd /openwhisk
   # disable reduce limits on views
   curl -X PUT http://$COUCHDB_USER:$COUCHDB_PASSWORD@$DB_HOST:$DB_PORT/_node/couchdb@couchdb0/_config/query_server_config/reduce_limit -d '"false"'
 
+  # create the couchdb system databases
+  curl -X PUT http://$COUCHDB_USER:$COUCHDB_PASSWORD@$DB_HOST:$DB_PORT/_users
+  curl -X PUT http://$COUCHDB_USER:$COUCHDB_PASSWORD@$DB_HOST:$DB_PORT/_replicator
+  curl -X PUT http://$COUCHDB_USER:$COUCHDB_PASSWORD@$DB_HOST:$DB_PORT/_global_changes
+
   pushd ansible
     # initialize the DB
     ansible-playbook -i environments/local initdb.yml \


### PR DESCRIPTION
As of CouchDB 2.0, system databases don't automatically get created on
startup and you have to do this manually. The process differs a bit
for single nodes vs clusters, but since everything else in the Ansible
scripts seems to assume single node this just sets things up that way.

See the CouchDB docs at
http://docs.couchdb.org/en/2.0.0/install/#single-node-setup for more
info.

This prevents errors constantly being logged by CouchDB with messages
like `Error in process <0.22878.7> on node 'couchdb@couchdb0' with
exit value: {database_does_not_exist ...` and `chttpd_auth_cache
changes listener died database_does_not_exist ...` which can end up
chewing through a lot of log disk space.