### PR TITLE
Use env variable other than hard code node name

### DIFF
--- a/kubernetes/couchdb/docker/init.sh
+++ b/kubernetes/couchdb/docker/init.sh
@@ -55,7 +55,7 @@ pushd /openwhisk
   popd
 
   # disable reduce limits on views
-  curl -X PUT http://$COUCHDB_USER:$COUCHDB_PASSWORD@$DB_HOST:$DB_PORT/_node/couchdb@couchdb0/_config/query_server_config/reduce_limit -d '"false"'
+  curl -X PUT http://$COUCHDB_USER:$COUCHDB_PASSWORD@$DB_HOST:$DB_PORT/_node/couchdb@$NODENAME/_config/query_server_config/reduce_limit -d '"false"'
 
   # create the couchdb system databases
   curl -X PUT http://$COUCHDB_USER:$COUCHDB_PASSWORD@$DB_HOST:$DB_PORT/_users


### PR DESCRIPTION
The node name `couchdb@couchdb0` here should use the environment variable `NODENAME` defined in kubernetes/couchdb/couchdb.yml, other than hard coded one.

Or else, it will cause the setting of `reduce_limit` fail because of `no such node: couchdb@couchdb0`.