### PR TITLE
Update counchdb image init script to avoid python package installatio…

### DIFF
--- a/kubernetes/couchdb/docker/init.sh
+++ b/kubernetes/couchdb/docker/init.sh
@@ -8,6 +8,8 @@ pushd /openwhisk
   # Install ansible requirements
   ./tools/ubuntu-setup/pip.sh
 
+  sudo pip install -U pip
+
   # upgrade cffi for ansible error on Debian Jesse
   pip install --upgrade cffi
   sudo pip install markupsafe


### PR DESCRIPTION
…n error.

Due to some package updates, the pip tool need to be updated before
installing ansible 2.3. Use pip install -U pip to update the package
to avoid package installation error during the start of couchdb container.