### PR TITLE
disable use of docker-runc by setting INVOKER_USE_RUNC to false

### DIFF
--- a/kubernetes/invoker/invoker.yml
+++ b/kubernetes/invoker/invoker.yml
@@ -55,6 +55,8 @@ spec:
             value: "latest"
           - name: "INVOKER_CONTAINER_NETWORK"
             value: "bridge"
+          - name: "INVOKER_USE_RUNC"
+            value: "false"
 
           # Properties for invoker image
           - name: "DOCKER_IMAGE_PREFIX"

--- a/kubernetes/invoker/invoker.yml
+++ b/kubernetes/invoker/invoker.yml
@@ -70,6 +70,12 @@ spec:
           - name: "INVOKER_INSTANCES"
             value: "1"
 
+          # Invoker assigned name. Derived from hostname
+          - name: "INVOKER_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+
           # Java options
           - name: "JAVA_OPTS"
             value: "-Xmx2g"
@@ -83,6 +89,12 @@ spec:
             value: "kafka.openwhisk"
           - name: "KAFKA_HOST_PORT"
             value: "9092"
+
+          # Redis properties
+          - name: "REDIS_HOST"
+            value: "redis.openwhisk"
+          - name: "REDIS_HOST_PORT"
+            value: "6379"
 
           # This property can change since it is generated via Ansible GroupVars
           - name: "RUNTIMES_MANIFEST"


### PR DESCRIPTION
Set envvar to disable use of docker-runc to pause/resume containers
(will use docker pause/unpause instead).