### PR TITLE
Use zookeeper instead of redis for dynamic invoker id assignment

### DIFF
--- a/kubernetes/invoker/invoker.yml
+++ b/kubernetes/invoker/invoker.yml
@@ -90,11 +90,11 @@ spec:
           - name: "KAFKA_HOST_PORT"
             value: "9092"
 
-          # Redis properties
-          - name: "REDIS_HOST"
-            value: "redis.openwhisk"
-          - name: "REDIS_HOST_PORT"
-            value: "6379"
+          # zookeeper info
+          - name: "ZOOKEEPER_HOST"
+            value: "zookeeper.openwhisk"
+          - name: "ZOOKEEPER_PORT"
+            value: "2181"
 
           # This property can change since it is generated via Ansible GroupVars
           - name: "RUNTIMES_MANIFEST"


### PR DESCRIPTION
Define ZooKeeper host and port instead of Redis host and port
in the environment of the invoker container (companion to OW #2916).