### PR TITLE
add configuration of Ingress and restructure docs accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,51 +61,28 @@ manually deploy the rest of the OpenWhisk components.
 * [Controller](kubernetes/controller/README.md)
 * [Invoker](kubernetes/invoker/README.md)
 * [Nginx](kubernetes/nginx/README.md)
+* [Ingress](kubernetes/ingress/README.md)
 
-From here, you will now need to get the publicly available address
-of Nginx. If you are using the default Nginx image with a NodePort
-Service, then you can obtain the public IP using the following guide:
+In the commands below, replace API_HOST with the URL appropriate for the Ingress you deployed.
 
- 1. Obtain the IP address of the Kubernetes nodes.
-
- ```
- kubectl get nodes
- ```
-
- 2. Obtain the public port for the Kubernetes Nginx Service
-
- ```
- kubectl -n openwhisk describe service nginx
- ```
-
- From here you should note the port used for the api endpoint. E.g:
-
- ```
- export WSK_PORT=$(kubectl -n openwhisk describe service nginx | grep https-api | grep NodePort| awk '{print $3}' | cut -d'/' -f1)
- ```
-
-Now you should be able to setup the wsk cli like normal and interact with
-Openwhisk.
+Configure the wsk cli by setting the auth and apihost properties.
 
 ```
-wsk property set --auth 23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP --apihost https://[nginx_ip]:$WSK_PORT
+wsk property set --auth 23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP --apihost https://API_HOST
 ```
 
-Lastly, you will need to install the initial catalog. To do this, you will need
-to set the `OPENWHISK_HOME` environment variable:
+Install the initial catalog. To do this, you will need to set
+the `OPENWHISK_HOME` environment variable:
 
 ```
 export OPENWHISK_HOME [location of the openwhisk repo]
 ```
 
-Then you should be able to run the following commands. Just make sure to
-replace the `[nginx_ip]` bellow.
-
 ```
   pushd /tmp
     git clone https://github.com/apache/incubator-openwhisk-catalog
     cd incubator-openwhisk-catalog/packages
-    ./installCatalog.sh 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP https://[nginx_ip]:$WSK_PORT
+    ./installCatalog.sh 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP https://API_HOST
   popd
 ```
 
@@ -131,11 +108,6 @@ to make a public image and once it is resolved, then we can switch to the public
 * Kube 1.6.3 has an issue with volume mount subpaths. See
   [here](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md#v163)
   for more information.
-
-## Enhancements
-
-* Use a public Edge Docker image once this [issue](https://github.com/apache/incubator-openwhisk/issues/2152)
-  is resolved
 
 # Issues
 

--- a/configure/cleanup.sh
+++ b/configure/cleanup.sh
@@ -20,6 +20,9 @@ kubectl -n openwhisk delete cm nginx
 # delete secrets
 kubectl -n openwhisk delete secret nginx
 
+# delete ingress
+kubectl -n openwhisk delete ingress ow-ingress
+
 # delete services
 kubectl -n openwhisk delete service couchdb
 kubectl -n openwhisk delete service redis

--- a/kubernetes/ingress/README.md
+++ b/kubernetes/ingress/README.md
@@ -1,0 +1,109 @@
+Ingress
+-------
+
+To make your OpenWhisk deployment available outside of Kubernetes, you
+need to configure an Ingress to expose the nginx service.
+Unfortunately, the exact details of configuring an Ingress vary across
+cloud providers.  The instructions below describe multiple possible
+Ingress configurations.  We welcome contributions from the community
+to describe how to configure ingress for all the major cloud provider
+providers.
+
+# NodePort
+
+When it was deployed, the nginx service was configured to expose
+itself via a NodePort [see](https://github.com/apache/incubator-openwhisk-deploy-kube/tree/master/kubernetes/nginx/nginx.yml#L10)
+By determining the IP address of a worker node and the exposed port
+number, you can determine your API_HOST. There are no additional files
+to apply. TLS termination is handled by the nginx service.
+
+ 1. Obtain the IP address of the Kubernetes nodes.
+
+ ```
+ kubectl get nodes
+ ```
+
+ 2. Obtain the public port for https port of the openwhisk.nginx Service
+
+ ```
+kubectl -n openwhisk describe service nginx | grep https-api | grep NodePort| awk '{print $3}' | cut -d'/' -f1
+ ```
+
+Use IP_ADDR:PUBLIC_PORT as your API_HOST
+
+
+# Simple Service Ingress
+
+A basic ingress that simply connects through to the nginx
+service. With this ingress, TLS termination will be handled by the
+OpenWhisk nginx service.
+
+```
+kubectl apply -f ingress-simple.yml
+````
+
+Use `kubectl get ingress` to determine the IP address and port to use
+to define API_HOST for a simple service ingress.
+
+# IBM Cloud
+
+## IBM Cloud Lite cluster
+
+The only available ingress method for a Lite cluster is to use a
+NodePort (see above).  By determining the IP address of a worker node
+and the exposed port number, you can determine your API_HOST. There
+are no additional files to apply. TLS termination is handled by the
+nginx service.
+
+ 1. Obtain the Public IP address of the sole worker node.
+
+ ```
+bx cs workers <my-cluster>
+ ```
+
+ 2. Obtain the public port for https port of the openwhisk.nginx Service
+
+ ```
+kubectl -n openwhisk describe service nginx | grep https-api | grep NodePort| awk '{print $3}' | cut -d'/' -f1
+ ```
+Use PublicIP:PORT as your API_HOST
+
+## IBM Cloud standard cluster
+
+A template file ingress-ibm.yml is provided.  You will need to edit
+this file to replace <ibmdomain> and <ibmtlssecret> with the correct
+values for your cluster. Note that <ibmdomain> appears twice in the
+template file.
+
+To determine this values, run the command
+```
+bx cs cluster-get <mycluster>
+```
+The CLI output will look something like
+```
+bx cs cluster-get <mycluster>
+Retrieving cluster <mycluster>...
+OK
+Name:    <mycluster>
+ID:    b9c6b00dc0aa487f97123440b4895f2d
+Created:  2017-04-26T19:47:08+0000
+State:    normal
+Master URL:  https://169.57.40.165:1931
+Ingress subdomain:  <ibmdomain>
+Ingress secret:  <ibmtlssecret>
+Workers:  3
+```
+You can see the IBM-provided domain in the Ingress subdomain and the
+IBM-provided certificate in the Ingress secret field.
+
+After editing the template file, deploy it.
+```
+kubectl apply -f ingress-ibm.yml
+```
+
+Your OpenWhisk API_HOST will be <ibmdomain>/openwhisk
+
+
+# Other cloud providers
+
+Please submit Pull Requests with instructions for other cloud providers.

--- a/kubernetes/ingress/ingress-ibm.yml
+++ b/kubernetes/ingress/ingress-ibm.yml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ow-ingress
+  namespace: openwhisk
+  annotations:
+    ingress.bluemix.net/rewrite-path: "serviceName=nginx rewrite=/"
+spec:
+  tls:
+  - hosts:
+    - <ibmdomain>
+    secretName: <ibmtlssecret>
+  rules:
+  - host: <ibmdomain>
+    http:
+      paths:
+      - path: /openwhisk/
+        backend:
+          serviceName: nginx
+          servicePort: 80

--- a/kubernetes/ingress/ingress-simple.yml
+++ b/kubernetes/ingress/ingress-simple.yml
@@ -1,0 +1,9 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ow-ingress
+  namespace: openwhisk
+spec:
+  backend:
+    serviceName: nginx
+    servicePort: 443

--- a/kubernetes/nginx/nginx.conf
+++ b/kubernetes/nginx/nginx.conf
@@ -12,6 +12,7 @@ http {
     access_log /logs/nginx_access.log combined-upstream;
 
     server {
+        listen 80;
         listen 443 default ssl;
 
         # match namespace, note while OpenWhisk allows a richer character set for a


### PR DESCRIPTION
Add configuring Ingress as a separate step and include examples
of using a NodePort, a Single Service Ingress, and configurations
for IBM Cloud Lite Cluster and IBM Cloud Standard Cluster.

Extend nginx.conf to also allow connection over port 80 (needed
when TLS termination is handled by the Ingress).

Minor restructuring of top-level configuration instructions
to push down details of how to determine the API_HOST for
OpenWhisk into the new ingress/README.md file.