### PR TITLE
service discovery via service ennvars

### DIFF
--- a/kubernetes/apigateway/apigateway.yml
+++ b/kubernetes/apigateway/apigateway.yml
@@ -45,6 +45,6 @@ spec:
           containerPort: 9000
         env:
         - name: "REDIS_HOST"
-          value: "redis.openwhisk"
+          value: "$(REDIS_SERVICE_HOST)"
         - name: "REDIS_PORT"
-          value: "6379"
+          value: "$(REDIS_SERVICE_PORT_REDIS)"

--- a/kubernetes/controller/controller.yml
+++ b/kubernetes/controller/controller.yml
@@ -69,7 +69,7 @@ spec:
 
         # Kafka properties
         - name: "KAFKA_HOSTS"
-          value: "kafka.openwhisk:9092"
+          value: "$(KAFKA_SERVICE_HOST):$(KAFKA_SERVICE_PORT_KAFKA)"
 
         # specific controller arguments
         - name: "CONTROLLER_INSTANCES"
@@ -110,12 +110,12 @@ spec:
           value: "whisk_admin"
         - name: "DB_PASSWORD"
           value: "some_passw0rd"
-        - name: "DB_PORT"
-          value: "5984"
         - name:  "DB_PROTOCOL"
           value: "http"
         - name: "DB_HOST"
-          value: "couchdb.openwhisk"
+          value: "$(COUCHDB_SERVICE_HOST)"
+        - name: "DB_PORT"
+          value: "$(COUCHDB_SERVICE_PORT_COUCHDB)"
         - name: "DB_PROVIDER"
           value: "CouchDB"
         - name: "DB_WHISK_ACTIONS_DDOC"

--- a/kubernetes/invoker/invoker.yml
+++ b/kubernetes/invoker/invoker.yml
@@ -86,11 +86,11 @@ spec:
 
           # Kafka properties
           - name: "KAFKA_HOSTS"
-            value: "kafka.openwhisk:9092"
+            value: "$(KAFKA_SERVICE_HOST):$(KAFKA_SERVICE_PORT_KAFKA)"
 
           # zookeeper info
           - name: "ZOOKEEPER_HOSTS"
-            value: "zookeeper.openwhisk:2181"
+            value: "$(ZOOKEEPER_SERVICE_HOST):$(ZOOKEEPER_SERVICE_PORT_ZOOKEEPER)"
 
           # This property can change since it is generated via Ansible GroupVars
           - name: "RUNTIMES_MANIFEST"
@@ -109,12 +109,12 @@ spec:
             value: "whisk_admin"
           - name: "DB_PASSWORD"
             value: "some_passw0rd"
-          - name: "DB_PORT"
-            value: "5984"
           - name:  "DB_PROTOCOL"
             value: "http"
           - name: "DB_HOST"
-            value: "couchdb.openwhisk"
+            value: "$(COUCHDB_SERVICE_HOST)"
+          - name: "DB_PORT"
+            value: "$(COUCHDB_SERVICE_PORT_COUCHDB)"
           - name: "DB_PROVIDER"
             value: "CouchDB"
           - name: "DB_WHISK_ACTIONS_DDOC"

--- a/kubernetes/kafka/kafka.yml
+++ b/kubernetes/kafka/kafka.yml
@@ -61,6 +61,6 @@ spec:
 
         # zookeeper info
         - name: "ZOOKEEPER_HOST"
-          value: "zookeeper.openwhisk"
+          value: "$(ZOOKEEPER_SERVICE_HOST)"
         - name: "ZOOKEEPER_PORT"
-          value: "2181"
+          value: "$(ZOOKEEPER_SERVICE_PORT_ZOOKEEPER)"


### PR DESCRIPTION
find services via service environment variables
instead of relying on kube-dns.