### PR TITLE
use KAFKA_SERVICE_HOST instead of kafka.openwhisk

### DIFF
--- a/kubernetes/kafka/kafka.yml
+++ b/kubernetes/kafka/kafka.yml
@@ -41,9 +41,9 @@ spec:
           containerPort: 9092
         env:
         - name: "KAFKA_ADVERTISED_HOST_NAME"
-          value: kafka.openwhisk
+          value: "$(KAFKA_SERVICE_HOST)"
         - name: "KAFKA_PORT"
-          value: "9092"
+          value: "$(KAFKA_SERVICE_PORT_KAFKA)"
 
         # message settings
         - name: "REPLICATION_FACTOR"


### PR DESCRIPTION
Fixes a place I missed in PR #102.