### PR TITLE
build fix: Travis deploy step must be a single script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ script:
 
 deploy:
 - provider: script
-  script:
-    - ./tools/travis/publish.sh openwhisk kube-couchdb latest docker/couchdb
-    - ./tools/travis/publish.sh openwhisk kube-routemgmt latest docker/routemgmt
+  script: ./tools/travis/deploy.sh
   on:
     branch: master

--- a/tools/travis/deploy.sh
+++ b/tools/travis/deploy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+SCRIPTDIR=$(cd $(dirname "$0") && pwd)
+ROOTDIR="$SCRIPTDIR/../../"
+
+cd $ROOTDIR
+
+echo "Publishing kube-couchdb image"
+./tools/travis/publish.sh openwhisk kube-couchdb latest docker/couchdb
+
+echo "Publishing kube-routemgmt image"
+./tools/travis/publish.sh openwhisk kube-routemgmt latest docker/routemgmt


### PR DESCRIPTION
Fix bug introduced in 9f8e75d7 -- didn't read the Travis CI docs
closely enough.  The deploy step with the script provider
must be a single script.