### PR TITLE
define Job to install openwhisk-catalog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - ./tools/travis/scancode.sh
   - ./tools/travis/build.sh
   - ./tools/travis/collect-logs.sh
-  - ./tools/travis/box-upload.py "$TRAVIS_BUILD_DIR/logs" "deploy-kube-$TRAVIS_BUILD_ID-$TRAVIS_BRANCH.tar.gz"
+  - ./tools/travis/box-upload.py "logs" "deploy-kube-$TRAVIS_BUILD_ID-$TRAVIS_BRANCH.tar.gz"
 
 deploy:
 - provider: script

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,6 +10,9 @@ The built images are:
     production usage.
   * routemgmt - installs OpenWhisk's route management package
     in the system namespace of the OpenWhisk deployment.
+  * openwhisk-catalog - installs the catalog from the project
+    incubator-openwhisk-calalog to the system namespace of the
+    OpenWhisk deployment.
 
 The nginx and kafka images are not officially built and published
 because they are considered to be temporary.  We are working on

--- a/docker/openwhisk-catalog/Dockerfile
+++ b/docker/openwhisk-catalog/Dockerfile
@@ -1,0 +1,10 @@
+from ubuntu:latest
+
+RUN apt-get -y update && apt-get -y install \
+  git \
+  wget
+
+COPY init.sh /init.sh
+RUN chmod +X /init.sh
+
+CMD ["/init.sh"]

--- a/docker/openwhisk-catalog/init.sh
+++ b/docker/openwhisk-catalog/init.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -x
+
+# Clone openwhisk-catalog
+# TODO: when openwhisk-catalog has releases, download release instead!
+git clone https://github.com/apache/incubator-openwhisk-catalog openwhisk-catalog
+
+# TODO: installCatalog.sh wants OPENWHISK_HOME set, but doesn't actually need
+# it for anything.  Fix upstream and then remove this.
+export OPENWHISK_HOME=/openwhisk
+mkdir -p $OPENWHISK_HOME/bin
+
+# Download and install openwhisk cli
+pushd $OPENWHISK_HOME/bin
+  wget -q https://github.com/apache/incubator-openwhisk-cli/releases/download/$WHISK_CLI_VERSION/OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz
+  tar xzf OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz
+popd
+
+# Run installCatalog.sh
+pushd openwhisk-catalog/packages
+  ./installCatalog.sh $WHISK_AUTH $WHISK_API_HOST_NAME $OPENWHISK_HOME/bin/wsk
+popd
+

--- a/kubernetes/openwhisk-catalog/README.md
+++ b/kubernetes/openwhisk-catalog/README.md
@@ -1,0 +1,14 @@
+OpenWhisk Catalog
+-----
+
+Once the system is deployed, we need to run a Job to install all the
+standard package catalog from incubator-openwhisk-catalog into the
+/whisk.system namespace.
+
+# Deploying
+
+To run the Job, you just need to run:
+
+```
+kubectl apply -f install-catalog.yml
+```

--- a/kubernetes/openwhisk-catalog/install-catalog.yml
+++ b/kubernetes/openwhisk-catalog/install-catalog.yml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: install-catalog
+spec:
+  activeDeadlineSeconds: 600
+  template:
+    metadata:
+      name: install-catalog
+    spec:
+      containers:
+      - name: catalog
+        image: openwhisk/kube-openwhisk-catalog
+        env:
+          - name: "WHISK_CLI_VERSION"
+            value: "latest"
+          - name: "WHISK_AUTH"
+            valueFrom:
+              secretKeyRef:
+                name: auth.whisk.system
+                key: auth.whisk.system
+          - name: "WHISK_API_HOST_NAME"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk
+                key: whisk_api_host_name
+      restartPolicy: Never

--- a/tools/travis/deploy.sh
+++ b/tools/travis/deploy.sh
@@ -12,3 +12,6 @@ echo "Publishing kube-couchdb image"
 
 echo "Publishing kube-routemgmt image"
 ./tools/travis/publish.sh openwhisk kube-routemgmt latest docker/routemgmt
+
+echo "Publishing kube-openwhisk-catalog image"
+./tools/travis/publish.sh openwhisk kube-openwhisk-catalog latest docker/openwhisk-catalog


### PR DESCRIPTION
Define Job and associated Docker image to install the
packages from incubator-openwhisk-catalog.  Not referenced
yet in top-level README.md and build.sh because we need to
wait for Travis to publish the new image to Dockerhub first.