### PR TITLE
Simplify routemgmt container

### DIFF
--- a/docker/routemgmt/Dockerfile
+++ b/docker/routemgmt/Dockerfile
@@ -3,13 +3,7 @@ from ubuntu:latest
 RUN apt-get -y update && apt-get -y install \
   git \
   wget \
-  zip \
-  python-dev \
-  python-pip
-
-RUN pip install --upgrade setuptools
-RUN pip install argcomplete
-RUN pip install ansible==2.3.0.0
+  zip
 
 COPY init.sh /init.sh
 RUN chmod +X /init.sh

--- a/docker/routemgmt/init.sh
+++ b/docker/routemgmt/init.sh
@@ -16,14 +16,23 @@ pushd bin
   tar xzf OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz
 popd
 
-# Generate whisk.properties.
-# TODO: Refactor upstream ansible/roles/routemgmt/files/installRouteMgmt.sh to enable
-# override of apigw values from environment so we don't have to bother running
-# ansible here to generate whisk.properties just so the script can extract 3 values.
-pushd ansible
-  ansible-playbook setup.yml
-  ansible-playbook properties.yml -e apigw_host_v2=$WHISK_API_GATEWAY_HOST_V2
-popd
+# Setup env for installRouteMgmt.sh
+if [ "$WHISK_API_GATEWAY_USER" ]; then
+    export GW_USER=$WHISK_API_GATEWAY_USER
+else
+    export GW_USER=' '
+fi
+if [ "$WHISK_API_GATEWAY_PASSWORD" ]; then
+    export GW_PWD=$WHISK_API_GATEWAY_PASSWORD
+else
+    export GW_PWD=' '
+fi
+if [ "$WHISK_API_GATEWAY_HOST_V2" ]; then
+    export GW_HOST_V2=$WHISK_API_GATEWAY_HOST_V2
+else
+    echo "Must provide a value for WHISK_API_GATEWAY_HOST_V2"
+    exit 1
+fi
 
 # Run installRouteMgmt.sh
 pushd ansible/roles/routemgmt/files


### PR DESCRIPTION
Upstream PR 3112 eliminated the need to generate whisk.properties
to run the installRouteMgmt.sh script.  Take advantage of this to
eliminate ansible from the docker image and streamline init.sh.