### PR TITLE
use configmap/secrets for CouchDB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Do one of the following:
   within the Kubernetes cluster.
 * For a production level CouchDB instance, take a look at the main
   OpenWhisk [documentation for configuring CouchDB](https://github.com/apache/incubator-openwhisk/blob/master/tools/db/README.md).
+  You will need to define the db.auth secret and db.config configmap as described in the [CouchDB README.md](kubernetes/couchdb/README.md)
+  to match your database deployment.
 
 ## Deploy Remaining Components
 

--- a/kubernetes/controller/controller.yml
+++ b/kubernetes/controller/controller.yml
@@ -91,17 +91,29 @@ spec:
 
         # properties for DB connection
         - name: "DB_USERNAME"
-          value: "whisk_admin"
+          valueFrom:
+            secretKeyRef:
+              name: db.auth
+              key: db_username
         - name: "DB_PASSWORD"
-          value: "some_passw0rd"
+          valueFrom:
+            secretKeyRef:
+              name: db.auth
+              key: db_password
         - name:  "DB_PROTOCOL"
-          value: "http"
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_protocol
         - name: "DB_HOST"
           value: "$(COUCHDB_SERVICE_HOST)"
         - name: "DB_PORT"
           value: "$(COUCHDB_SERVICE_PORT_COUCHDB)"
         - name: "DB_PROVIDER"
-          value: "CouchDB"
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_provider
         - name: "DB_WHISK_ACTIONS_DDOC"
           value: "whisks.v2"
         - name: "DB_WHISK_ACTIVATIONS_DDOC"
@@ -109,8 +121,17 @@ spec:
         - name: "DB_WHISK_ACTIVATIONS_FILTER_DDOC"
           value: "whisks-filters.v2"
         - name: "DB_WHISK_ACTIVATIONS"
-          value: "test_activations"
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_whisk_activations
         - name: "DB_WHISK_ACTIONS"
-          value: "test_whisks"
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_whisk_actions
         - name: "DB_WHISK_AUTHS"
-          value: "test_subjects"
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_whisk_auths

--- a/kubernetes/couchdb/README.md
+++ b/kubernetes/couchdb/README.md
@@ -3,6 +3,27 @@ CouchDB
 
 # Deploying
 
+## Create secret and configmap
+
+The db.auth secret and db.config configmap contain authorization and
+configuration information for the CouchDB instance being used for this
+OpenWhisk deployment.  The db.auth secret is expected to define two
+keys: db_username and db_password. The db.config configmap is expected
+to define five keys: db_protocol, db_provider, db_prefix,
+db_whisk_activations, db_whisk_actions, and db_whisk_auths. The
+commands below create them with default values; adjust as needed for
+your deployment.
+
+```
+kubectl -n openwhisk create secret generic db.auth --from-literal=db_username=whisk_admin --from-literal=db_password=some_passw0rd
+```
+
+```
+kubectl -n openwhisk create configmap db.config --from-literal=db_protocol=http --from-literal=db_provider=CouchDB --from-literal=db_whisk_activations=test_activations --from-literal=db_whisk_actions=test_whisks --from-literal=db_whisk_auths=test_subjects --from-literal=db_prefix=test_
+```
+
+## Deploy the CouchDB pod
+
 To deploy CouchDB, you first need to create the CouchDB
 Pod. This can be done by running:
 
@@ -14,32 +35,22 @@ This pod goes through the process of pulling the OpenWhisk
 repo and running through some of the ansible playbooks for
 configuring CouchDB.
 
-**NOTE** the pod will say running as soon as the start command
-runs, but it does not actually mean that the DB is ready to use.
-This is because it might not yet be configured. To check if the
-DB has been setup, you can look at the Pod logs with
+**NOTE** the pod will say running as soon as the start command runs,
+but that does not mean that CouchDB is really running and ready to
+use. It typically takes about a minute until setup has completed and
+the database is actually usable. Examine the pods logs with
 
 ```
 kubectl -n openwhisk logs -lname=couchdb
 ```
 
-In the logs, you should see the line:
+and look for the line:
 
 ```
-Apache CouchDB has started on http://0.0.0.0:5984
+successfully setup and configured CouchDB
 ```
 
-This indicates that the CouchDB instancs is up and running.
-
-# Configuring CouchDB
-## Usernames and Passwords
-
-To configure custom usernames and passwords, you can edit
-the CouchDB [setup pod](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/kubernetes/couchdb/couchdb.yml#L48-L51).
-
-**NOTE** If the CouchDB username and password properties
-are updated, then you will need to update the Controller
-and Invoker yamls with updated username and password.
+This indicates that the CouchDB instance is fully configured and ready to use.
 
 ## Persistance
 

--- a/kubernetes/couchdb/couchdb.yml
+++ b/kubernetes/couchdb/couchdb.yml
@@ -42,13 +42,22 @@ spec:
           containerPort: 5984
         env:
         - name: "DB_PREFIX"
-          value: "test_"
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_prefix
         - name: "DB_HOST"
           value: "127.0.0.1"
         - name: "COUCHDB_USER"
-          value: "whisk_admin"
+          valueFrom:
+            secretKeyRef:
+              name: db.auth
+              key: db_username
         - name: "COUCHDB_PASSWORD"
-          value: "some_passw0rd"
+          valueFrom:
+            secretKeyRef:
+              name: db.auth
+              key: db_password
         - name: "DB_PORT"
           value: "5984"
         - name: "NODENAME"
@@ -56,6 +65,8 @@ spec:
         readinessProbe:
           httpGet:
             port: 5984
+            # Tempting to say "/$(DB_PREFIX)_activations", but probe runs
+            # externally, therefore can't access the container environment...
             path: "/test_activations"
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/kubernetes/invoker/invoker.yml
+++ b/kubernetes/invoker/invoker.yml
@@ -108,17 +108,29 @@ spec:
 
           # properties for DB connection
           - name: "DB_USERNAME"
-            value: "whisk_admin"
+            valueFrom:
+              secretKeyRef:
+                name: db.auth
+                key: db_username
           - name: "DB_PASSWORD"
-            value: "some_passw0rd"
+            valueFrom:
+              secretKeyRef:
+                name: db.auth
+                key: db_password
           - name:  "DB_PROTOCOL"
-            value: "http"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_protocol
           - name: "DB_HOST"
             value: "$(COUCHDB_SERVICE_HOST)"
           - name: "DB_PORT"
             value: "$(COUCHDB_SERVICE_PORT_COUCHDB)"
           - name: "DB_PROVIDER"
-            value: "CouchDB"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_provider
           - name: "DB_WHISK_ACTIONS_DDOC"
             value: "whisks.v2"
           - name: "DB_WHISK_ACTIVATIONS_DDOC"
@@ -126,11 +138,20 @@ spec:
           - name: "DB_WHISK_ACTIVATIONS_FILTER_DDOC"
             value: "whisks-filters.v2"
           - name: "DB_WHISK_ACTIVATIONS"
-            value: "test_activations"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_whisk_activations
           - name: "DB_WHISK_ACTIONS"
-            value: "test_whisks"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_whisk_actions
           - name: "DB_WHISK_AUTHS"
-            value: "test_subjects"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_whisk_auths
 
           # Name for the pod can be the hostname of the Kube node
           - name: "INVOKER_NAME"

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -12,7 +12,7 @@ couchdbHealthCheck () {
   PASSED=false
   TIMEOUT=0
   until [ $TIMEOUT -eq 30 ]; do
-    if [ -n "$(kubectl -n openwhisk logs $POD_NAME | grep "successfully setup and configured CouchDB v2.0")" ]; then
+    if [ -n "$(kubectl -n openwhisk logs $POD_NAME | grep "successfully setup and configured CouchDB")" ]; then
       PASSED=true
       break
     fi
@@ -163,6 +163,8 @@ popd
 # setup couchdb
 echo "Deploying couchdb"
 pushd kubernetes/couchdb
+  kubectl -n openwhisk create secret generic db.auth --from-literal=db_username=whisk_admin --from-literal=db_password=some_passw0rd
+  kubectl -n openwhisk create configmap db.config --from-literal=db_protocol=http --from-literal=db_provider=CouchDB --from-literal=db_whisk_activations=test_activations --from-literal=db_whisk_actions=test_whisks --from-literal=db_whisk_auths=test_subjects --from-literal=db_prefix=test_
   kubectl apply -f couchdb.yml
 
   couchdbHealthCheck


### PR DESCRIPTION
Move DB authorization and configuration information to
configmap and secret to eliminate duplication of information
throughout the yml files.