### PR TITLE
bugfix for setting WSK_HOST on minikube

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -158,7 +158,7 @@ popd
 pushd kubernetes/ingress
   WSK_PORT=$(kubectl -n openwhisk describe service nginx | grep https-api | grep NodePort| awk '{print $3}' | cut -d'/' -f1)
   APIGW_PORT=$(kubectl -n openwhisk describe service apigateway | grep mgmt | grep NodePort| awk '{print $3}' | cut -d'/' -f1)
-  WSK_HOST=$(kubectl describe nodes | grep Hostname: | awk '{print $2}')
+  WSK_HOST=$(minikube ip)
   kubectl -n openwhisk create configmap whisk.ingress --from-literal=api_host=$WSK_HOST:$WSK_PORT --from-literal=apigw_url=http://$WSK_HOST:$APIGW_PORT
   wsk property set --auth `cat ../cluster-setup/auth.guest` --apihost $WSK_HOST:$WSK_PORT
 popd
@@ -277,7 +277,7 @@ if [ -z "$RESULT" ]; then
   kubectl -n openwhisk logs controller-0
 
   echo " ----------------------------- invoker logs ---------------------------"
-  kubectl -n openwhisk logs invoker-0
+  kubectl -n openwhisk logs -l name=invoker
   exit 1
 fi
 


### PR DESCRIPTION
When minikube isn't using the none driver, the Hostname
returned from `kubectl describe nodes` may not be resolvable.
Use `minikube ip` instead to get an ip addr for WSK_HOST.

Also update the logs command that runs when the script fails
to use the name=invoker label (missed when we converted the
invoker from statefulsets to daemonsets).