### PR TITLE
default to non-HA controller configuration

### DIFF
--- a/kubernetes/controller/README.md
+++ b/kubernetes/controller/README.md
@@ -25,7 +25,9 @@ kubectl apply -f controller.yml
 # Controller Deployment Changes
 ## Changing the Controller Count
 
-Changing the number of controllers currently requires a complete
+By default, only a single controller is deployed (HA disabled).
+
+Changing the number of controllers and/or enabling HA currently requires a complete
 redeployment of the controller stateful set. You will need to update
 the number of replicas
 [here](https://github.com/apache/incubator-openwhisk-deploy-kube/tree/master/kubernetes/controller/controller.yml#L10)

--- a/kubernetes/controller/controller.yml
+++ b/kubernetes/controller/controller.yml
@@ -7,7 +7,7 @@ metadata:
   labels:
     name: controller
 spec:
-  replicas: 2
+  replicas: 1
   serviceName: "controller"
   template:
     metadata:
@@ -28,13 +28,13 @@ spec:
         # Properties for controller HA configuration
         # Must change these if changing number of replicas
         - name: "CONTROLLER_LOCALBOOKKEEPING"
-          value: "FALSE"
-        - name: "CONTROLLER_HA"
           value: "TRUE"
+        - name: "CONTROLLER_HA"
+          value: "FALSE"
         - name: "CONTROLLER_INSTANCES"
-          value: "2"
+          value: "1"
         - name: "AKKA_CLUSTER_SEED_NODES"
-          value: "controller-0.controller.openwhisk controller-1.controller.openwhisk"
+          value: "controller-0.controller.openwhisk"
         - name: "CONFIG_akka_actor_provider"
           value: "cluster"
 


### PR DESCRIPTION
Matches default local deployment of upstream project,
which does not deploy any of the OpenWhisk components
for HA.