### PR TITLE
plumbing for INVOKER_CONTAINER_DNS

### DIFF
--- a/kubernetes/invoker/invoker.env
+++ b/kubernetes/invoker/invoker.env
@@ -1,6 +1,7 @@
 java_opts=-Xmx2g
 invoker_opts=
 invoker_container_network=bridge
+invoker_container_dns=
 invoker_use_runc=false
 docker_image_prefix=openwhisk
 docker_image_tag=latest

--- a/kubernetes/invoker/invoker.yml
+++ b/kubernetes/invoker/invoker.yml
@@ -89,6 +89,11 @@ spec:
               configMapKeyRef:
                 name: invoker.config
                 key: invoker_container_network
+          - name: "INVOKER_CONTAINER_DNS"
+            valueFrom:
+              configMapKeyRef:
+                name: invoker.config
+                key: invoker_container_dns
           - name: "INVOKER_USE_RUNC"
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
Flow the setting of invoker_container_dns from the
invoker config map to the invoker pod's environment
to enable setting custom dns servers for an openwhisk
deployment.

Fixes #86