### PR TITLE
Define initial network policies for OpenWhisk deployment

### DIFF
--- a/kubernetes/controller/controller.yml
+++ b/kubernetes/controller/controller.yml
@@ -160,3 +160,30 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 1
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: controller-netpol
+  namespace: openwhisk
+spec:
+  podSelector:
+    matchLabels:
+      name: controller
+  ingress:
+  # Allow nginx to connect to controller
+  - from:
+    - podSelector:
+        matchLabels:
+          name: nginx
+    ports:
+     - port: 8080
+  # Controllers can connect to each other
+  - from:
+    - podSelector:
+        matchLabels:
+          name: controller
+    ports:
+     - port: 8080
+     - port: 2552

--- a/kubernetes/couchdb/couchdb.yml
+++ b/kubernetes/couchdb/couchdb.yml
@@ -72,3 +72,28 @@ spec:
           periodSeconds: 10
           failureThreshold: 10
           timeoutSeconds: 1
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: couchdb-netpol
+  namespace: openwhisk
+spec:
+  podSelector:
+    matchLabels:
+      name: couchdb
+  ingress:
+  # Allow controller, invoker, and any pod with access=db to connect to couchdb
+  - from:
+    - podSelector:
+        matchLabels:
+          name: controller
+    - podSelector:
+        matchLabels:
+          name: invoker
+    - podSelector:
+        matchLabels:
+          access: db
+    ports:
+     - port: 5984

--- a/kubernetes/kafka/kafka.yml
+++ b/kubernetes/kafka/kafka.yml
@@ -39,3 +39,32 @@ spec:
         # zookeeper info
         - name: "KAFKA_ZOOKEEPER_CONNECT"
           value: "$(ZOOKEEPER_SERVICE_HOST):$(ZOOKEEPER_SERVICE_PORT_ZOOKEEPER)"
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kafka-netpol
+  namespace: openwhisk
+spec:
+  podSelector:
+    matchLabels:
+      name: kafka
+  ingress:
+  # Allow invoker and controller to connect to kafka
+  - from:
+    - podSelector:
+        matchLabels:
+          name: controller
+    - podSelector:
+        matchLabels:
+          name: invoker
+    ports:
+     - port: 9092
+  # kafkas can connect to each other
+  - from:
+    - podSelector:
+        matchLabels:
+          name: kafka
+    ports:
+     - port: 9092

--- a/kubernetes/zookeeper/zookeeper.yml
+++ b/kubernetes/zookeeper/zookeeper.yml
@@ -1,4 +1,3 @@
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -26,3 +25,33 @@ spec:
           containerPort: 2888
         - name: leader-election
           containerPort: 3888
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: zookeeper-netpol
+  namespace: openwhisk
+spec:
+  podSelector:
+    matchLabels:
+      name: zookeeper
+  ingress:
+  # Allow kafka and invoker to connect to zookeeper
+  - from:
+    - podSelector:
+        matchLabels:
+          name: kafka
+    - podSelector:
+        matchLabels:
+          name: invoker
+    ports:
+     - port: 2181
+  # zookeepers can connect to each other
+  - from:
+    - podSelector:
+        matchLabels:
+          name: zookeeper
+    ports:
+     - port: 2181
+     - port: 2888
+     - port: 3888


### PR DESCRIPTION
Initial configuration of a network policy for the OpenWhisk
control plane that whitelists specific communication patterns
for zookeeper, kafka, couchdbm controller, and invoker.

Note kube 1.7.x seems to only support defining ingress rules;
looks like we need to get to 1.8.x before we can specify egress.