### PR TITLE
fix Travis CI regression introduced in 84f6e38d

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -158,7 +158,10 @@ popd
 pushd kubernetes/ingress
   WSK_PORT=$(kubectl -n openwhisk describe service nginx | grep https-api | grep NodePort| awk '{print $3}' | cut -d'/' -f1)
   APIGW_PORT=$(kubectl -n openwhisk describe service apigateway | grep mgmt | grep NodePort| awk '{print $3}' | cut -d'/' -f1)
-  WSK_HOST=$(minikube ip)
+  WSK_HOST=$(kubectl describe nodes | grep Hostname: | awk '{print $2}')
+  if [ "$WSK_HOST" = "minikube" ]; then
+      WSK_HOST=$(minikube ip)
+  fi
   kubectl -n openwhisk create configmap whisk.ingress --from-literal=api_host=$WSK_HOST:$WSK_PORT --from-literal=apigw_url=http://$WSK_HOST:$APIGW_PORT
   wsk property set --auth `cat ../cluster-setup/auth.guest` --apihost $WSK_HOST:$WSK_PORT
 popd


### PR DESCRIPTION
Only use `minikube ip` to get WSK_HOST when `kubectl describe nodes`
returns "minikube" as the hostname.  When running with the none driver
(like in travis CI), minikube ip returns local host, which works
for the wsk CLI externally, but not for the wsk CLI when invoked
from a Job running within minikube.

Regression was not detected during PR testing because the fix
of 63f96636 to check error conditions in the job's init.sh has not
been merged to master when 84f6e38d was tested.