### PR TITLE
container network/dns converted to PureConfig

### DIFF
--- a/kubernetes/invoker/invoker.yml
+++ b/kubernetes/invoker/invoker.yml
@@ -93,12 +93,12 @@ spec:
                 key: api_host
 
           # Docker-related options
-          - name: "INVOKER_CONTAINER_NETWORK"
+          - name: "CONFIG_whisk_containerFactory_containerArgs_network"
             valueFrom:
               configMapKeyRef:
                 name: invoker.config
                 key: invoker_container_network
-          - name: "INVOKER_CONTAINER_DNS"
+          - name: "CONFIG_whisk_containerFactory_containerArgs_dnsServers"
             valueFrom:
               configMapKeyRef:
                 name: invoker.config


### PR DESCRIPTION
update envvar names for OpenWhisk PR#3198 which moved
network and DNS container args to PureConfig.