### PR TITLE
update runtimes.json for OW#3259

### DIFF
--- a/docker/docker-pull/pull_images.yml
+++ b/docker/docker-pull/pull_images.yml
@@ -8,6 +8,10 @@
     docker_pull_delay: 10
     docker_registry:
     runtimesManifest: "{{ lookup('env', 'RUNTIMES_MANIFEST') | from_json }}"
+    dip: "{{ lookup('env', 'DEFAULT_IMAGE_PREFIX') }}"
+    defaultImagePrefix: "{{ dip if dip != '' else 'openwhisk'}}"
+    dit: "{{ lookup('env', 'DEFAULT_IMAGE_TAG') }}"
+    defaultImageTag: "{{ dit if dit != '' else 'latest' }}"
 
   tasks:
     - name: docker login
@@ -17,15 +21,15 @@
         password: "{{ docker_registry_password }}"
       when: docker_registry != "" and docker_registry_password is defined
 
-    - name: "pull runtime action images with tag {{runtimesManifest.defaultImageTag}}"
-      shell: "docker pull {{docker_registry}}{{runtimesManifest.defaultImagePrefix}}/{{item}}:{{runtimesManifest.defaultImageTag}}"
+    - name: "pull runtime action images with tag {{defaultImageTag}}"
+      shell: "docker pull {{docker_registry}}{{defaultImagePrefix}}/{{item}}:{{defaultImageTag}}"
       with_items: "{{ runtimesManifest.runtimes.values() | sum(start=[]) | selectattr('deprecated', 'equalto',false)  | map(attribute='image.name') | list | unique }}"
       when: docker_registry != ""
       retries: "{{ docker_pull_retries }}"
       delay: "{{ docker_pull_delay }}"
 
-    - name: "pull blackboxes action images with tag {{runtimesManifest.defaultImageTag}}"
-      shell: "docker pull {{docker_registry}}{{runtimesManifest.defaultImagePrefix}}/{{item.name}}:{{runtimesManifest.defaultImageTag}}"
+    - name: "pull blackboxes action images with tag {{defaultImageTag}}"
+      shell: "docker pull {{docker_registry}}{{defaultImagePrefix}}/{{item.name}}:{{defaultImageTag}}"
       with_items:
         - "{{ runtimesManifest.blackboxes }}"
       when: docker_registry != ""

--- a/kubernetes/cluster-setup/runtimes.json
+++ b/kubernetes/cluster-setup/runtimes.json
@@ -1,7 +1,4 @@
 {
-    "bypassPullForLocalImages": false,
-    "defaultImagePrefix": "openwhisk",
-    "defaultImageTag": "latest",
     "runtimes": {
         "nodejs": [
             {


### PR DESCRIPTION
Upstream PR https://github.com/apache/incubator-openwhisk/pull/3259 moved
bypassPullForLocalImages, defaultImagePrefix, and defaultImageTag from 
runtimes.json to application.conf.

Make the same change in the kube copy of runtimes.json.