### PR TITLE
Add simple loadtesting jobs

### DIFF
--- a/kubernetes/apigateway/apigateway.yml
+++ b/kubernetes/apigateway/apigateway.yml
@@ -26,6 +26,16 @@ spec:
                 operator: NotIn
                 values:
                 - invoker
+        # prefer to run on a control-plane node
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: In
+                values:
+                - control-plane
         # do not allow more than 1 apigateway instance to run on a node
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/cluster-setup/services.yml
+++ b/kubernetes/cluster-setup/services.yml
@@ -57,7 +57,6 @@ metadata:
 spec:
   selector:
     name: controller
-  clusterIP: None
   ports:
     - port: 8080
       targetPort: 8080

--- a/kubernetes/controller/controller.yml
+++ b/kubernetes/controller/controller.yml
@@ -27,6 +27,16 @@ spec:
                 operator: NotIn
                 values:
                 - invoker
+        # prefer to run on a control-plane node
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: In
+                values:
+                - control-plane
         # do not allow more than 1 controller instance to run on a node
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -194,11 +204,14 @@ spec:
     matchLabels:
       name: controller
   ingress:
-  # Allow nginx to connect to controller
+  # Allow nginx and any pod with access=controller to connect to controller
   - from:
     - podSelector:
         matchLabels:
           name: nginx
+    - podSelector:
+        matchLabels:
+          access: controller
     ports:
      - port: 8080
   # Controllers can connect to each other

--- a/kubernetes/couchdb/couchdb.yml
+++ b/kubernetes/couchdb/couchdb.yml
@@ -44,6 +44,16 @@ spec:
                 operator: NotIn
                 values:
                 - invoker
+        # prefer to run on a control-plane node
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: In
+                values:
+                - control-plane
         # do not allow more than 1 couchdb instance to run on a given node
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/kafka/kafka.yml
+++ b/kubernetes/kafka/kafka.yml
@@ -26,6 +26,16 @@ spec:
                 operator: NotIn
                 values:
                 - invoker
+        # prefer to run on a control-plane node
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: In
+                values:
+                - control-plane
         # do not allow more than 1 kafka instance to run on a given node
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/loadtest/README.md
+++ b/kubernetes/loadtest/README.md
@@ -1,0 +1,24 @@
+LoadTest
+-----
+
+A collection of jobs to do performance testing
+against openwhisk deployed on kube, based on
+the code in apache/incubator-openwhisk-performance.git.
+
+The jobs are intended to run in the openwhisk namespace in the same
+cluster as the system under test to eliminate external network
+latency.
+
+# Preparing
+
+The Jobs assume the noopLatency and noopThroughput actions are already
+created in the default namespace.  These actions are simple noops
+(for example a JavaScript action whose body is `function main(){return {};}`).
+
+# Runnning
+
+To run one of the Jobs, edit the yml to adjust test parameters and then
+
+```
+kubectl apply -f loadtest-latency.yml
+```

--- a/kubernetes/loadtest/loadtest-latency-internal.yml
+++ b/kubernetes/loadtest/loadtest-latency-internal.yml
@@ -1,0 +1,57 @@
+# This Job measures internal latency (no ingress, no TLS termination) by
+# hitting the controller service directly.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: loadtest-latency-internal
+  namespace: openwhisk
+spec:
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      name: loadtest-latency-internal
+      labels:
+        access: controller
+    spec:
+      affinity:
+        # do not run on a node that openwhisk is actually using
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: NotIn
+                values:
+                - invoker
+                - control-plane
+                - edge
+        # prefer to run on a loadtest node
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: In
+                values:
+                - loadtest
+      containers:
+      - name: loadtest
+        image: markusthoemmes/loadtest
+        env:
+          # number of samples to gather
+          - name: "NUM_SAMPLES"
+            value: "10000"
+          # base64 encoding of default auth.guest credentials
+          - name: "ENCODED_AUTH"
+            value: "MjNiYzQ2YjEtNzFmNi00ZWQ1LThjNTQtODE2YWE0ZjhjNTAyOjEyM3pPM3haQ0xyTU42djJCS0sxZFhZRnBYbFBrY2NPRnFtMTJDZEFzTWdSVTRWck5aOWx5R1ZDR3VNREdJd1A="
+          - name: "WHISK_API_HOST_NAME"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.ingress
+                key: api_host
+        command: ["loadtest"]
+        args: ["-n", "$(NUM_SAMPLES)", "-k", "-m", "POST", "-H", "Authorization: basic $(ENCODED_AUTH)", "http://$(CONTROLLER_SERVICE_HOST):$(CONTROLLER_SERVICE_PORT)/api/v1/namespaces/_/actions/noopLatency?blocking=true"]
+      restartPolicy: Never

--- a/kubernetes/loadtest/loadtest-latency.yml
+++ b/kubernetes/loadtest/loadtest-latency.yml
@@ -1,0 +1,54 @@
+# This Job measures end-to-end latency by hitting the public ingress.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: loadtest-latency
+  namespace: openwhisk
+spec:
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      name: loadtest-latency
+    spec:
+      affinity:
+        # do not run on a node that openwhisk is actually using
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: NotIn
+                values:
+                - invoker
+                - control-plane
+                - edge
+        # prefer to run on a loadtest node
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: In
+                values:
+                - loadtest
+      containers:
+      - name: loadtest
+        image: markusthoemmes/loadtest
+        env:
+          # number of samples to gather
+          - name: "NUM_SAMPLES"
+            value: "10000"
+          # base64 encoding of default auth.guest credentials
+          - name: "ENCODED_AUTH"
+            value: "MjNiYzQ2YjEtNzFmNi00ZWQ1LThjNTQtODE2YWE0ZjhjNTAyOjEyM3pPM3haQ0xyTU42djJCS0sxZFhZRnBYbFBrY2NPRnFtMTJDZEFzTWdSVTRWck5aOWx5R1ZDR3VNREdJd1A="
+          - name: "WHISK_API_HOST_NAME"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.ingress
+                key: api_host
+        command: ["loadtest"]
+        args: ["-n", "$(NUM_SAMPLES)", "-k", "-m", "POST", "-H", "Authorization: basic $(ENCODED_AUTH)", "$(WHISK_API_HOST_NAME)/api/v1/namespaces/_/actions/noopLatency?blocking=true"]
+      restartPolicy: Never

--- a/kubernetes/loadtest/loadtest-throughput.yml
+++ b/kubernetes/loadtest/loadtest-throughput.yml
@@ -1,0 +1,58 @@
+# This Job measures throughput obtainable by hitting the public ingress.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: loadtest-throughput-512x1024x300sec
+  namespace: openwhisk
+spec:
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      name: loadtest-throughput-512x1024x300sec
+    spec:
+      affinity:
+        # do not run on a node that openwhisk is actually using
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: NotIn
+                values:
+                - invoker
+                - control-plane
+                - edge
+        # prefer to run on a loadtest node
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: In
+                values:
+                - loadtest
+      containers:
+      - name: loadtest
+        image: williamyeh/wrk
+        env:
+          # number of samples to gather
+          - name: "DURATION"
+            value: "300"
+          - name: "CONCURRENCY"
+            value: "1024"
+          - name: "NUM_CORES"
+            value: "512"
+          # base64 encoding of default auth.guest credentials
+          - name: "ENCODED_AUTH"
+            value: "MjNiYzQ2YjEtNzFmNi00ZWQ1LThjNTQtODE2YWE0ZjhjNTAyOjEyM3pPM3haQ0xyTU42djJCS0sxZFhZRnBYbFBrY2NPRnFtMTJDZEFzTWdSVTRWck5aOWx5R1ZDR3VNREdJd1A="
+          - name: "WHISK_API_HOST_NAME"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.ingress
+                key: api_host
+        command: ["/bin/sh"]
+        args: ["-c", "echo wrk.method = \\\"POST\\\" > post.lua; wrk --threads $(NUM_CORES) --connections $(CONCURRENCY) --duration $(DURATION) --header \"Authorization: basic $(ENCODED_AUTH)\" $(WHISK_API_HOST_NAME)/api/v1/namespaces/_/actions/noopThroughput?blocking=true --latency --timeout 10s --script post.lua"]
+      restartPolicy: Never

--- a/kubernetes/nginx/nginx.yml
+++ b/kubernetes/nginx/nginx.yml
@@ -26,6 +26,16 @@ spec:
                 operator: NotIn
                 values:
                 - invoker
+        # prefer to run on an edge node
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: In
+                values:
+                - edge
         # do not allow more than 1 nginx instance to run on a given node
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/zookeeper/zookeeper.yml
+++ b/kubernetes/zookeeper/zookeeper.yml
@@ -25,6 +25,16 @@ spec:
                 operator: NotIn
                 values:
                 - invoker
+        # prefer to run on a control-plane node
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: openwhisk-role
+                operator: In
+                values:
+                - control-plane
         # do not allow more than 1 zookeeper instance to run on a given node
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Add simple latency and throughput microbenchmaking
jobs based on incubator-openwhisk-performance.

Also add pod affinity/anti-affinity annotations to help
guide pods to specific kinds of nodes when deploying
on larger clusters with mixes of worker nodes.