### PR TITLE
reduce number of runtimes for docker-pull during TravisCI testing 

### DIFF
--- a/kubernetes/cluster-setup/runtimes-minimal-travis.json
+++ b/kubernetes/cluster-setup/runtimes-minimal-travis.json
@@ -1,0 +1,28 @@
+{
+    "runtimes": {
+        "nodejs": [
+            {
+                "kind": "nodejs:6",
+                "default": true,
+                "image": {
+                    "name": "nodejs6action"
+                },
+                "deprecated": false
+            }
+        ],
+        "python": [
+            {
+                "kind": "python:3",
+                "image": {
+                    "name": "python3action"
+                },
+                "deprecated": false
+            }
+        ]
+    },
+    "blackboxes": [
+        {
+            "name": "dockerskeleton"
+        }
+    ]
+}

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -148,7 +148,12 @@ pushd kubernetes/cluster-setup
   kubectl apply -f namespace.yml
   kubectl apply -f services.yml
   kubectl -n openwhisk create cm whisk.config --from-env-file=config.env
-  kubectl -n openwhisk create cm whisk.runtimes --from-file=runtimes=runtimes.json
+  if [ "$TRAVIS" = "true" ]; then
+      # when running a CI job, skip pulling images we don't need to significantly reduce testing time.
+      kubectl -n openwhisk create cm whisk.runtimes --from-file=runtimes=runtimes-minimal-travis.json
+  else
+      kubectl -n openwhisk create cm whisk.runtimes --from-file=runtimes=runtimes.json
+  fi
   kubectl -n openwhisk create cm whisk.limits --from-env-file=limits.env
   kubectl -n openwhisk create secret generic whisk.auth --from-file=system=auth.whisk.system --from-file=guest=auth.guest
 popd


### PR DESCRIPTION
pulling all the runtime docker images takes a significant fraction
of the overall testing time.  Just pull the one image we actually need
to execute our test cases to reduce test time.