### PR TITLE
put db_host and db_port in db.config configmap

### DIFF
--- a/kubernetes/controller/controller.yml
+++ b/kubernetes/controller/controller.yml
@@ -156,9 +156,15 @@ spec:
               name: db.config
               key: db_protocol
         - name: "CONFIG_whisk_couchdb_host"
-          value: "$(COUCHDB_SERVICE_HOST)"
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_host
         - name: "CONFIG_whisk_couchdb_port"
-          value: "$(COUCHDB_SERVICE_PORT_COUCHDB)"
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_port
         - name: "CONFIG_whisk_couchdb_provider"
           valueFrom:
             configMapKeyRef:

--- a/kubernetes/couchdb/README.md
+++ b/kubernetes/couchdb/README.md
@@ -9,9 +9,9 @@ The db.auth secret and db.config configmap contain authorization and
 configuration information for the CouchDB instance being used for this
 OpenWhisk deployment.  The db.auth secret is expected to define two
 keys: db_username and db_password. The db.config configmap is expected
-to define seven keys: db_protocol, db_provider, db_host, db_port, db_prefix,
-db_whisk_activations, db_whisk_actions, and db_whisk_auths. The
-commands below create them with default values; adjust as needed for
+to define the following keys: db_protocol, db_provider, db_host, db_port,
+db_prefix, db_whisk_activations, db_whisk_actions, and db_whisk_auths.
+The commands below create them with default values; adjust as needed for
 your deployment.
 
 ```

--- a/kubernetes/couchdb/README.md
+++ b/kubernetes/couchdb/README.md
@@ -9,7 +9,7 @@ The db.auth secret and db.config configmap contain authorization and
 configuration information for the CouchDB instance being used for this
 OpenWhisk deployment.  The db.auth secret is expected to define two
 keys: db_username and db_password. The db.config configmap is expected
-to define five keys: db_protocol, db_provider, db_prefix,
+to define seven keys: db_protocol, db_provider, db_host, db_port, db_prefix,
 db_whisk_activations, db_whisk_actions, and db_whisk_auths. The
 commands below create them with default values; adjust as needed for
 your deployment.
@@ -19,7 +19,7 @@ kubectl -n openwhisk create secret generic db.auth --from-literal=db_username=wh
 ```
 
 ```
-kubectl -n openwhisk create configmap db.config --from-literal=db_protocol=http --from-literal=db_provider=CouchDB --from-literal=db_whisk_activations=test_activations --from-literal=db_whisk_actions=test_whisks --from-literal=db_whisk_auths=test_subjects --from-literal=db_prefix=test_
+kubectl -n openwhisk create configmap db.config --from-literal=db_protocol=http --from-literal=db_provider=CouchDB --from-literal=db_host=couchdb.openwhisk.svc.cluster.local --from-literal=db_port=5984 --from-literal=db_whisk_activations=test_activations --from-literal=db_whisk_actions=test_whisks --from-literal=db_whisk_auths=test_subjects --from-literal=db_prefix=test_
 ```
 
 ## Deploy the CouchDB pod

--- a/kubernetes/invoker/invoker-dcf.yml
+++ b/kubernetes/invoker/invoker-dcf.yml
@@ -172,9 +172,15 @@ spec:
                 name: db.config
                 key: db_protocol
           - name: "CONFIG_whisk_couchdb_host"
-            value: "$(COUCHDB_SERVICE_HOST)"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_host
           - name: "CONFIG_whisk_couchdb_port"
-            value: "$(COUCHDB_SERVICE_PORT_COUCHDB)"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_port
           - name: "CONFIG_whisk_couchdb_provider"
             valueFrom:
               configMapKeyRef:

--- a/kubernetes/invoker/invoker-k8scf.yml
+++ b/kubernetes/invoker/invoker-k8scf.yml
@@ -177,9 +177,15 @@ spec:
                 name: db.config
                 key: db_protocol
           - name: "CONFIG_whisk_couchdb_host"
-            value: "$(COUCHDB_SERVICE_HOST)"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_host
           - name: "CONFIG_whisk_couchdb_port"
-            value: "$(COUCHDB_SERVICE_PORT_COUCHDB)"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_port
           - name: "CONFIG_whisk_couchdb_provider"
             valueFrom:
               configMapKeyRef:

--- a/kubernetes/package-kafka/README.md
+++ b/kubernetes/package-kafka/README.md
@@ -11,6 +11,8 @@ kubectl -n openwhisk create cm packages.kafkaprovider --from-literal=kafkapkg_db
 The deployment also has dependencies to secret `whisk.auth` and `db.auth`, and configmap `whisk.ingress`. Make sure you have these settings before you start the deployment.
 
 ## Step 1. Install kafka provider
+Note, if you are using an external CouchDB or Cloudant database for your deployment, you will need to edit the definition of DB_URL in kafkaprovider.yml.
+
 ```
 kubectl apply -f kafkaprovider.yml
 ```

--- a/kubernetes/package-kafka/kafkapkginstaller.yml
+++ b/kubernetes/package-kafka/kafkapkginstaller.yml
@@ -23,9 +23,15 @@ spec:
               name: whisk.ingress
               key: api_host
         - name: "DB_HOST"
-          value: "$(COUCHDB_SERVICE_HOST)"
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_host
         - name: "DB_PORT"
-          value: "$(COUCHDB_SERVICE_PORT_COUCHDB)"
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_port
         - name: "DB_USERNAME"
           valueFrom:
             secretKeyRef:

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -175,7 +175,7 @@ popd
 echo "Deploying couchdb"
 pushd kubernetes/couchdb
   kubectl -n openwhisk create secret generic db.auth --from-literal=db_username=whisk_admin --from-literal=db_password=some_passw0rd
-  kubectl -n openwhisk create configmap db.config --from-literal=db_protocol=http --from-literal=db_provider=CouchDB --from-literal=db_whisk_activations=test_activations --from-literal=db_whisk_actions=test_whisks --from-literal=db_whisk_auths=test_subjects --from-literal=db_prefix=test_
+  kubectl -n openwhisk create configmap db.config --from-literal=db_protocol=http --from-literal=db_provider=CouchDB --from-literal=db_host=couchdb.openwhisk.svc.cluster.local --from-literal=db_port=5984 --from-literal=db_whisk_activations=test_activations --from-literal=db_whisk_actions=test_whisks --from-literal=db_whisk_auths=test_subjects --from-literal=db_prefix=test_
   kubectl apply -f couchdb.yml
 
   couchdbHealthCheck


### PR DESCRIPTION
Better support for using an external (not in kube) database by
eliminating the assumption that there must be a couchdb service and
instead getting the db_host and db_port from the db.config configmap.