### PR TITLE
configurable timeout for travis/build.sh

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -11,7 +11,7 @@ couchdbHealthCheck () {
 
   PASSED=false
   TIMEOUT=0
-  until [ $TIMEOUT -eq 60 ]; do
+  until [ $TIMEOUT -eq $TIMEOUT_STEP_LIMIT ]; do
     if [ -n "$(kubectl -n openwhisk logs $POD_NAME | grep "successfully setup and configured CouchDB")" ]; then
       PASSED=true
       break
@@ -39,7 +39,7 @@ deploymentHealthCheck () {
 
   PASSED=false
   TIMEOUT=0
-  until $PASSED || [ $TIMEOUT -eq 60 ]; do
+  until $PASSED || [ $TIMEOUT -eq $TIMEOUT_STEP_LIMIT ]; do
     KUBE_DEPLOY_STATUS=$(kubectl -n openwhisk get pods -l name="$1" -o wide | grep "$1" | awk '{print $3}')
     if [ "$KUBE_DEPLOY_STATUS" == "Running" ]; then
       PASSED=true
@@ -70,7 +70,7 @@ statefulsetHealthCheck () {
 
   PASSED=false
   TIMEOUT=0
-  until $PASSED || [ $TIMEOUT -eq 60 ]; do
+  until $PASSED || [ $TIMEOUT -eq $TIMEOUT_STEP_LIMIT ]; do
     KUBE_DEPLOY_STATUS=$(kubectl -n openwhisk get pods -l name="$1" -o wide | grep "$1"-0 | awk '{print $3}')
     if [ "$KUBE_DEPLOY_STATUS" == "Running" ]; then
       PASSED=true
@@ -102,7 +102,7 @@ jobHealthCheck () {
 
   PASSED=false
   TIMEOUT=0
-  until $PASSED || [ $TIMEOUT -eq 60 ]; do
+  until $PASSED || [ $TIMEOUT -eq $TIMEOUT_STEP_LIMIT ]; do
     KUBE_SUCCESSFUL_JOB=$(kubectl -n openwhisk get jobs -o wide | grep "$1" | awk '{print $3}')
     if [ "$KUBE_SUCCESSFUL_JOB" == "1" ]; then
       PASSED=true
@@ -137,6 +137,9 @@ ROOTDIR="$SCRIPTDIR/../../"
 
 # Default to docker container factory if not specified
 OW_CONTAINER_FACTORY=${OW_CONTAINER_FACTORY:="docker"}
+
+# Default timeout limit to 60 steps
+TIMEOUT_STEP_LIMIT=${TIMEOUT_STEP_LIMIT:=60}
 
 cd $ROOTDIR
 


### PR DESCRIPTION
Add hook to allow overriding the timeout value used when waiting for a
pod to be successfully deployed.  I've found when running locally on a
fresh minikube VM, it can sometimes take an excessively long time to
pull images from dockerhub into the docker registry within the
minikube cluster.  Setting a high timeout limit avoids needing to run
the script multiple times to pull in the needed images.