### PR TITLE
helm: get runtimes from runtimes.json

### DIFF
--- a/helm/runtimes-minimal-travis.json
+++ b/helm/runtimes-minimal-travis.json
@@ -1,0 +1,28 @@
+{
+    "runtimes": {
+        "nodejs": [
+            {
+                "kind": "nodejs:6",
+                "default": true,
+                "image": {
+                    "name": "nodejs6action"
+                },
+                "deprecated": false
+            }
+        ],
+        "python": [
+            {
+                "kind": "python:3",
+                "image": {
+                    "name": "python3action"
+                },
+                "deprecated": false
+            }
+        ]
+    },
+    "blackboxes": [
+        {
+            "name": "dockerskeleton"
+        }
+    ]
+}

--- a/helm/runtimes.json
+++ b/helm/runtimes.json
@@ -1,0 +1,101 @@
+{
+    "runtimes": {
+        "nodejs": [
+            {
+                "kind": "nodejs",
+                "image": {
+                    "name": "nodejsaction"
+                },
+                "deprecated": true
+            },
+            {
+                "kind": "nodejs:6",
+                "default": true,
+                "image": {
+                    "name": "nodejs6action"
+                },
+                "deprecated": false
+            },
+            {
+                "kind": "nodejs:8",
+                "default": false,
+                "image": {
+                    "name": "action-nodejs-v8"
+                },
+                "deprecated": false
+            }
+        ],
+        "python": [
+            {
+                "kind": "python",
+                "image": {
+                    "name": "python2action"
+                },
+                "deprecated": false
+            },
+            {
+                "kind": "python:2",
+                "default": true,
+                "image": {
+                    "name": "python2action"
+                },
+                "deprecated": false
+            },
+            {
+                "kind": "python:3",
+                "image": {
+                    "name": "python3action"
+                },
+                "deprecated": false
+            }
+        ],
+        "swift": [
+            {
+                "kind": "swift:3.1.1",
+                "image": {
+                    "name": "action-swift-v3.1.1"
+                },
+                "deprecated": false
+            },
+            {
+                "kind": "swift:4.1",
+                "default": true,
+                "image": {
+                    "name": "action-swift-v4.1"
+                },
+                "deprecated": false
+            }
+        ],
+        "java": [
+            {
+                "kind": "java",
+                "default": true,
+                "image": {
+                    "name": "java8action"
+                },
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "jarfile",
+                    "attachmentType": "application/java-archive"
+                },
+                "sentinelledLogs": false,
+                "requireMain": true
+            }
+        ],
+        "php": [
+            {
+                "kind": "php:7.1",
+                "default": true,
+                "deprecated": false,
+                "image": {
+                    "name": "action-php-v7.1"
+                }
+            }
+        ]
+    },
+    "blackboxes": [
+        {
+            "name": "dockerskeleton"
+        }
+    ]
+}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -83,3 +83,12 @@
 {{- define "redis_url" -}}
 {{ .Values.global.redisServiceName | default "redis" }}.{{ .Release.Namespace }}
 {{- end -}}
+
+{{/* Runtimes manifest */}}
+{{- define "runtimes_manifest" -}}
+{{- if .Values.global.travis -}}
+{{ .Files.Get "runtimes-minimal-travis.json" | quote }}
+{{- else -}}
+{{ .Files.Get "runtimes.json" | quote }}
+{{- end -}}
+{{- end -}}

--- a/helm/templates/controller_statefulset.yml
+++ b/helm/templates/controller_statefulset.yml
@@ -83,9 +83,9 @@ spec:
         - name: "LOADBALANCER_INVOKERBUSYTHRESHOLD"
           value: "16"
 
-        # This needs to stay up to date with the lates runtime in Ansible Groupvars
+        # action runtimes
         - name: "RUNTIMES_MANIFEST"
-          value: '{ "defaultImagePrefix": "openwhisk", "defaultImageTag": "latest", "runtimes": { "nodejs": [ { "kind": "nodejs", "image": { "name": "nodejsaction" }, "deprecated": true }, { "kind": "nodejs:6", "default": true, "image": { "name": "nodejs6action" }, "deprecated": false } ], "python": [ { "kind": "python", "image": { "name": "python2action" }, "deprecated": false }, { "kind": "python:2", "default": true, "image": { "name": "python2action" }, "deprecated": false }, { "kind": "python:3", "image": { "name": "python3action" }, "deprecated": false } ], "swift": [ { "kind": "swift", "image": { "name": "swiftaction" }, "deprecated": true }, { "kind": "swift:3", "image": { "name": "swift3action" }, "deprecated": false }, { "kind": "swift:3.1.1", "default": true, "image": { "name": "action-swift-v3.1.1" }, "deprecated": false } ], "java": [ { "kind": "java", "default": true, "image": { "name": "java8action" }, "deprecated": false, "attached": { "attachmentName": "jarfile", "attachmentType": "application/java-archive" }, "sentinelledLogs": false, "requireMain": true } ] }, "blackboxes": [ { "name": "dockerskeleton" } ] }'
+          value: {{ template "runtimes_manifest" . }}
 
         # this version is the day it is deployed and should be configured every time
         - name:  "WHISK_VERSION_DATE"

--- a/helm/templates/invoker_deployment.yml
+++ b/helm/templates/invoker_deployment.yml
@@ -53,7 +53,18 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       {{- end }}
      
-      initContainers: 
+      initContainers:
+      - name: docker-pull-runtimes
+        imagePullPolicy: "IfNotPresent"
+        image: openwhisk/kube-docker-pull
+        volumeMounts:
+        - name: dockersock
+          mountPath: "/var/run/docker.sock"
+        env:
+          # action runtimes
+          - name: "RUNTIMES_MANIFEST"
+            value: {{ template "runtimes_manifest" . }}
+
       - name: "wait-for-kafka"
         image: "busybox"
         imagePullPolicy: "IfNotPresent"
@@ -99,9 +110,9 @@ spec:
           - name: "INVOKER_OPTS"
             value: {{ .Values.invokerOptions | quote }}
 
-          # This property can change since it is generated via Ansible GroupVars
+          # action runtimes
           - name: "RUNTIMES_MANIFEST"
-            value: '{ "defaultImagePrefix": "openwhisk", "defaultImageTag": "latest", "runtimes": { "nodejs": [ { "kind": "nodejs", "image": { "name": "nodejsaction" }, "deprecated": true }, { "kind": "nodejs:6", "default": true, "image": { "name": "nodejs6action" }, "deprecated": false } ], "python": [ { "kind": "python", "image": { "name": "python2action" }, "deprecated": false }, { "kind": "python:2", "default": true, "image": { "name": "python2action" }, "deprecated": false }, { "kind": "python:3", "image": { "name": "python3action" }, "deprecated": false } ], "swift": [ { "kind": "swift", "image": { "name": "swiftaction" }, "deprecated": true }, { "kind": "swift:3", "image": { "name": "swift3action" }, "deprecated": false }, { "kind": "swift:3.1.1", "default": true, "image": { "name": "action-swift-v3.1.1" }, "deprecated": false } ], "java": [ { "kind": "java", "default": true, "image": { "name": "java8action" }, "deprecated": false, "attached": { "attachmentName": "jarfile", "attachmentType": "application/java-archive" }, "sentinelledLogs": false, "requireMain": true } ] }, "blackboxes": [ { "name": "dockerskeleton" } ] }'
+            value: {{ template "runtimes_manifest" . }}
 
           # Default to empty logs dir. This is because logs should go to stdout
           - name: "WHISK_LOGS_DIR"


### PR DESCRIPTION
1. The set of runtimes is now read from runtimes.json
(or runtime-minimal-travis.json) instead of being hardwired.

2. Add init container to invoker_deployment to do docker pull of runtimes.