### PR TITLE
bump ansible to 2.5.2

### DIFF
--- a/docker/couchdb/Dockerfile
+++ b/docker/couchdb/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install argcomplete
 RUN pip install couchdb
 RUN pip install --upgrade cffi
 RUN pip install markupsafe
-RUN pip install ansible==2.5.0
+RUN pip install ansible==2.5.2
 RUN pip install -U pyopenssl
 
 COPY init.sh /init.sh

--- a/docker/docker-pull/Dockerfile
+++ b/docker/docker-pull/Dockerfile
@@ -13,7 +13,7 @@ rm -f docker-${DOCKER_VERSION}.tgz && \
 chmod +x /usr/bin/docker
 
 RUN pip install --upgrade setuptools
-RUN pip install ansible==2.5.0
+RUN pip install ansible==2.5.2
 RUN pip install jinja2==2.9.6
 
 COPY pull_images.yml /pull_images.yml


### PR DESCRIPTION
Version bump to ansible 2.5.2 as a workaround for
a bug (https://github.com/ansible/ansible/issues/37850) in ansible 2.5.0.