### PR TITLE
Reorganize values.yaml and simplify helper usage

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,91 +1,16 @@
-{{/* Set controller service name */}}
-{{- define "controller_service_name" -}}
-{{ .Values.controller.serviceName | quote }}
-{{- end -}}
-
-{{/* Set controller statefulset name */}}
-{{- define "controller_statefulset_name" -}}
-{{ .Values.controller.statefulSetName | quote }}
-{{- end -}}
-
-{{/* Set controller port */}}
-{{- define "controller_port" -}}
-{{ .Values.controller.port }}
-{{- end -}}
-
-{{/* Set activations table */}}
-{{- define "activations_table" -}}
-{{ .Values.db.activationsTable | quote }}
-{{- end -}}
-
-{{/* Set activations table */}}
-{{- define "activations_table_unquoted" -}}
-{{ .Values.db.activationsTable }}
-{{- end -}}
-
-{{/* Set actions table */}}
-{{- define "actions_table" -}}
-{{ .Values.db.actionsTable | quote }}
-{{- end -}}
-
-{{/* Set auths table */}}
-{{- define "auths_table" -}}
-{{ .Values.db.authsTable | quote }}
-{{- end -}}
-
-{{/* Set invoker "deployment" name */}}
-{{- define "invoker_deployment_name" -}}
-{{ .Values.invokerDeploymentName | quote }}
-{{- end -}}
-
 {{/* Generate kafka url without port */}}
 {{- define "kafka_url_without_port" -}}
-{{ .Values.kafka.serviceName }}.{{ .Release.Namespace }}
+{{ .Values.kafka.name }}.{{ .Release.Namespace }}
 {{- end -}}
 
 {{/* Generate Zookeeper service address */}}
 {{- define "zookeeper_service_address" -}}
-{{ .Values.zookeeper.serviceName }}.{{ .Release.Namespace }}:{{ .Values.zookeeper.port }}
-{{- end -}}
-
-{{/* Set Couchdb user name */}}
-{{- define "couchdb_username" -}}
-{{ .Values.db.auth.username | quote }}
-{{- end -}}
-
-{{/* Set Couchdb password */}}
-{{- define "couchdb_password" -}}
-{{ .Values.db.auth.password | quote }}
+{{ .Values.zookeeper.name }}.{{ .Release.Namespace }}:{{ .Values.zookeeper.port }}
 {{- end -}}
 
 {{/* Generate Couchdb url without port */}}
 {{- define "couchdb_url_without_port" -}}
-{{ .Values.db.serviceName }}.{{ .Release.Namespace }}
-{{- end -}}
-
-{{/* Set Couchdb port */}}
-{{- define "couchdb_port" -}}
-{{ .Values.db.port }}
-{{- end -}}
-
-{{/* Set API Gateway service name */}}
-{{- define "apigateway_service_name" -}}
-{{ .Values.apigw.serviceName | quote }}
-{{- end -}}
-
-{{/* Set API Gateway management port */}}
-{{- define "apigateway_mgmt_port" -}}
-{{ .Values.apigw.mgmtPort }}
-{{- end -}}
-
-{{/* Set API Gateway API port */}}
-{{- define "apigateway_api_port" -}}
-{{ .Values.apigw.apiPort }}
-{{- end -}}
-
-{{/* Set API Gateway deployment name */}}
-{{- define "apigateway_deployment_name" -}}
-{{ .Values.apigw.deploymentName | quote }}
+{{ .Values.db.name }}.{{ .Release.Namespace }}
 {{- end -}}
 
 {{/* Runtimes manifest */}}
@@ -100,11 +25,11 @@
 {{/* Environment variables required for accessing CouchDB */}}
 {{- define "whisk.dbEnvVars" -}}
 - name: "CONFIG_whisk_couchdb_username"
-  value: {{ template "couchdb_username" . }}
+  value: {{ .Values.db.auth.username | quote }}
 - name: "CONFIG_whisk_couchdb_password"
-  value: {{ template "couchdb_password" . }}
+  value: {{ .Values.db.auth.password | quote }}
 - name: "CONFIG_whisk_couchdb_port"
-  value: {{ include "couchdb_port" . | quote}}
+  value: {{ .Values.db.port | quote}}
 - name: "CONFIG_whisk_couchdb_protocol"
   value: "http"
 - name: "CONFIG_whisk_couchdb_host"
@@ -112,9 +37,9 @@
 - name: "CONFIG_whisk_couchdb_provider"
   value: "CouchDB"
 - name: "CONFIG_whisk_couchdb_databases_WhiskActivation"
-  value: {{ template "activations_table" . }}
+  value: {{ .Values.db.activationsTable | quote }}
 - name: "CONFIG_whisk_couchdb_databases_WhiskEntity"
-  value: {{ template "actions_table" . }}
+  value: {{ .Values.db.actionsTable | quote }}
 - name: "CONFIG_whisk_couchdb_databases_WhiskAuth"
-  value: {{ template "auths_table" . }}
+  value: {{ .Values.db.authsTable | quote }}
 {{- end -}}

--- a/helm/templates/_readiness.tpl
+++ b/helm/templates/_readiness.tpl
@@ -5,7 +5,7 @@
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"
-    value: http://{{ .Values.db.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.db.port }}/{{ template "activations_table_unquoted" . }}
+    value: http://{{ .Values.db.name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.db.port }}/{{ .Values.db.activationsTable }}
   command: ["sh", "-c", "result=1; until [ $result -eq 0 ]; do echo verifying CouchDB readiness; wget -T 5 --spider $READINESS_URL; result=$?; sleep 1; done;"]
 {{- end -}}
 
@@ -15,7 +15,7 @@
   image: "busybox"
   imagePullPolicy: "IfNotPresent"
   # TODO: I haven't found an easy external test to determine that kafka is up, so as a hack we wait for zookeeper and then sleep for 10 seconds and cross our fingers!
-  command: ["sh", "-c", 'result=1; until [ $result -eq 0 ]; do OK=$(echo ruok | nc -w 1 {{ .Values.zookeeper.serviceName}}.{{ .Release.Namespace }}.svc.cluster.local {{ .Values.zookeeper.port }}); if [ "$OK" == "imok" ]; then result=0; fi; echo waiting for zookeeper to be ready; sleep 1; done; echo zookeeper is up, sleeping for 10 seconds; sleep 10;']
+  command: ["sh", "-c", 'result=1; until [ $result -eq 0 ]; do OK=$(echo ruok | nc -w 1 {{ .Values.zookeeper.name}}.{{ .Release.Namespace }}.svc.cluster.local {{ .Values.zookeeper.port }}); if [ "$OK" == "imok" ]; then result=0; fi; echo waiting for zookeeper to be ready; sleep 1; done; echo zookeeper is up, sleeping for 10 seconds; sleep 10;']
 {{- end -}}
 
 {{/* Init container that waits for zookeeper to be ready */}}
@@ -23,7 +23,7 @@
 - name: "wait-for-zookeeper"
   image: "busybox"
   imagePullPolicy: "IfNotPresent"
-  command: ["sh", "-c", 'result=1; until [ $result -eq 0 ]; do OK=$(echo ruok | nc -w 1 {{ .Values.zookeeper.serviceName}}.{{ .Release.Namespace }}.svc.cluster.local {{ .Values.zookeeper.port }}); if [ "$OK" == "imok" ]; then result=0; fi; echo waiting for zookeeper to be ready; sleep 1; done']
+  command: ["sh", "-c", 'result=1; until [ $result -eq 0 ]; do OK=$(echo ruok | nc -w 1 {{ .Values.zookeeper.name}}.{{ .Release.Namespace }}.svc.cluster.local {{ .Values.zookeeper.port }}); if [ "$OK" == "imok" ]; then result=0; fi; echo waiting for zookeeper to be ready; sleep 1; done']
 {{- end -}}
 
 {{/* Init container that waits for controller to be ready */}}
@@ -33,6 +33,6 @@
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"
-    value: http://{{ .Values.controller.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.controller.port }}/ping
+    value: http://{{ .Values.controller.name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.controller.port }}/ping
   command: ["sh", "-c", "result=1; until [ $result -eq 0 ]; do echo verifying controller readiness; wget -T 5 --spider $READINESS_URL; result=$?; sleep 1; done;"]
 {{- end -}}

--- a/helm/templates/apigateway.yaml
+++ b/helm/templates/apigateway.yaml
@@ -2,57 +2,58 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "apigateway_service_name" . }}
+  name: {{ .Values.apigw.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    name: {{ template "apigateway_service_name" . }}
+    name: {{ .Values.apigw.name | quote }}
 spec:
   selector:
-    name: {{ template "apigateway_deployment_name" . }}
+    name: {{ .Values.apigw.name | quote }}
   ports:
-    - port: {{ template "apigateway_mgmt_port" . }}
-      targetPort: {{ template "apigateway_mgmt_port" . }}
+    - port: {{ .Values.apigw.mgmtPort }}
       name: mgmt
-    - port: {{ template "apigateway_api_port" . }}
-      targetPort: {{ template "apigateway_api_port" . }}
+    - port: {{ .Values.apigw.apiPort }}
+      {{- if .Values.apigw.apiNodePorthttpsNodePort }}
+      nodePort: {{ .Values.apigw.apiNodePort }}
+      {{- end }}
       name: api
 
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "apigateway_deployment_name" . }}
+  name: {{ .Values.apigw.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    name: {{ template "apigateway_deployment_name" . }}
+    name: {{ .Values.apigw.name | quote }}
 spec:
-  replicas: {{ .Values.apigatewayReplicaCount }}
+  replicas: {{ .Values.apigw.replicaCount }}
   template:
     metadata:
       labels:
-        name: {{ template "apigateway_deployment_name" . }}
+        name: {{ .Values.apigw.name | quote }}
     spec:
-      restartPolicy: Always
+      restartPolicy: {{ .Values.apigw.restartPolicy }}
 
       {{- if .Values.affinity.enabled }}
       affinity:
 {{ include "affinity.controlPlane" . | indent 8 }}
-{{ include "affinity.selfAntiAffinity" ( include "apigateway_deployment_name" . ) | indent 8 }}
+{{ include "affinity.selfAntiAffinity" ( .Values.apigw.name | quote ) | indent 8 }}
       {{- end }}
 
       containers:
         - name: redis
-          imagePullPolicy: {{ .Values.apigatewayImagePullPolicy | quote }}
+          imagePullPolicy: {{ .Values.apigw.imagePullPolicy | quote }}
           image: redis:3.2
 
         - name: apigateway
-          imagePullPolicy: {{ .Values.apigatewayImagePullPolicy | quote }}
-          image: {{ .Values.apigatewayImage | quote }}
+          imagePullPolicy: {{ .Values.apigw.imagePullPolicy | quote }}
+          image: {{ .Values.apigw.image | quote }}
           ports:
           - name: mgmt
-            containerPort: {{ template "apigateway_mgmt_port" . }}
+            containerPort: {{ .Values.apigw.mgmtPort }}
           - name: api
-            containerPort: {{ template "apigateway_api_port" . }}
+            containerPort: {{ .Values.apigw.apiPort }}
           env:
           - name: "REDIS_HOST"
             value: "127.0.0.1"

--- a/helm/templates/controller.yaml
+++ b/helm/templates/controller.yaml
@@ -2,39 +2,38 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "controller_service_name" . }}
+  name: {{ .Values.controller.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    name: {{ template "controller_service_name" . }}
+    name: {{ .Values.controller.name | quote }}
 spec:
   selector:
-    name: {{ template "controller_statefulset_name" . }}
+    name: {{ .Values.controller.name | quote }}
   ports:
-    - port: {{ template "controller_port" . }}
-      targetPort: {{ template "controller_port" . }}
+    - port: {{ .Values.controller.port }}
       name: http
 ---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: {{ template "controller_statefulset_name" . }}
+  name: {{ .Values.controller.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    name: {{ template "controller_statefulset_name" . }} 
+    name: {{ .Values.controller.name | quote }}
 spec:
-  replicas: {{ .Values.controllerReplicaCount }}
-  serviceName: {{ template "controller_service_name" . }}
+  replicas: {{ .Values.controller.replicaCount }}
+  name: {{ .Values.controller.name | quote }}
   template:
     metadata:
       labels:
-        name: {{ template "controller_statefulset_name" . }}
+        name: {{ .Values.controller.name | quote }}
     spec:
-      restartPolicy: Always
+      restartPolicy: {{ .Values.controller.restartPolicy }}
 
       {{- if .Values.affinity.enabled }}
       affinity:
 {{ include "affinity.controlPlane" . | indent 8 }}
-{{ include "affinity.selfAntiAffinity" ( include "controller_statefulset_name" . ) | indent 8 }}
+{{ include "affinity.selfAntiAffinity" ( .Values.controller.name | quote ) | indent 8 }}
       {{- end }}
 
       initContainers:
@@ -43,24 +42,24 @@ spec:
 {{ include "readiness.waitForCouchDB" . | indent 6 }}
 
       containers:
-      - name: {{ template "controller_statefulset_name" . }}
+      - name: {{ .Values.controller.name | quote }}
         imagePullPolicy: {{ .Values.controller.imagePullPolicy | quote }}
         image: {{ .Values.controller.image | quote }}
         command: ["/bin/bash", "-c", "COMPONENT_NAME=$(hostname | cut -d'-' -f2) /init.sh `hostname | cut -d'-' -f2`"]
         ports:
         - name: controller
-          containerPort: {{ template "controller_port" . }}
+          containerPort: {{ .Values.controller.port }}
         livenessProbe:
           httpGet:
             path: "/ping"
-            port: {{ template "controller_port" . }}
+            port: {{ .Values.controller.port }}
             scheme: "HTTP"
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 1
         env:
         - name: "PORT"
-          value: {{ include "controller_port" . | quote }}
+          value: {{ .Values.controller.port | quote }}
 
         # Loadbalancer options
         - name: "LOADBALANCER_INVOKERBUSYTHRESHOLD"

--- a/helm/templates/couchdb.yaml
+++ b/helm/templates/couchdb.yaml
@@ -1,16 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.db.serviceName | quote }}
+  name: {{ .Values.db.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    name: {{ .Values.db.serviceName | quote }}
+    name: {{ .Values.db.name | quote }}
 spec:
   selector:
-    name: {{ .Values.db.serviceName | quote }}
+    name: {{ .Values.db.name | quote }}
   ports:
     - port: {{ .Values.db.port }}
-      targetPort: {{ .Values.db.port }}
       name: couchdb
 
 {{- if and .Values.db.persistence.enabled (not .Values.db.persistence.existingClaim) }}
@@ -61,27 +60,27 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Values.db.deploymentName | quote }}
+  name: {{ .Values.db.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    name: {{ .Values.db.deploymentName | quote }}
+    name: {{ .Values.db.name | quote }}
 spec:
   replicas: {{ .Values.db.replicaCount }}
   template:
     metadata:
       labels:
-        name: {{ .Values.db.deploymentName | quote }}
+        name: {{ .Values.db.name | quote }}
     spec:
-      restartPolicy: Always
+      restartPolicy: {{ .Values.db.restartPolicy }}
 
       {{- if .Values.affinity.enabled }}
       affinity:
 {{ include "affinity.controlPlane" . | indent 8 }}
-{{ include "affinity.selfAntiAffinity" ( .Values.db.deploymentName ) | indent 8 }}
+{{ include "affinity.selfAntiAffinity" ( .Values.db.name ) | indent 8 }}
       {{- end }}
 
       containers:
-      - name: {{ .Values.db.deploymentName | quote }}
+      - name: {{ .Values.db.name | quote }}
         imagePullPolicy: {{ .Values.db.imagePullPolicy | quote }}
         image: {{ .Values.db.image | quote }}
         command: ["/init.sh"]
@@ -104,7 +103,7 @@ spec:
         readinessProbe:
           httpGet:
             port: {{ .Values.db.port }}
-            path: /{{ template "activations_table_unquoted" . }}
+            path: /{{ .Values.db.activationsTable }}
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 10

--- a/helm/templates/invoker.yaml
+++ b/helm/templates/invoker.yaml
@@ -1,17 +1,17 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: {{ template "invoker_deployment_name" . }}
+  name: {{ .Values.invoker.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    name: {{ template "invoker_deployment_name" . }}
+    name: {{ .Values.invoker.name | quote }}
 spec:
   template:
     metadata:
       labels:
-        name: {{ template "invoker_deployment_name" . }}
+        name: {{ .Values.invoker.name | quote }}
     spec:
-      restartPolicy: Always
+      restartPolicy: {{ .Values.invoker.restartPolicy }}
 
       affinity:
 {{ include "affinity.invoker" . | indent 8 }}
@@ -36,7 +36,7 @@ spec:
 
       # Pull images for all default runtimes before starting invoker
       - name: docker-pull-runtimes
-        imagePullPolicy: "IfNotPresent"
+        imagePullPolicy: {{ .Values.invoker.imagePullPolicy | quote }}
         image: openwhisk/kube-docker-pull
         volumeMounts:
         - name: dockersock
@@ -47,14 +47,10 @@ spec:
             value: {{ template "runtimes_manifest" . }}
 
       containers:
-      - name: {{ template "invoker_deployment_name" . }}
-        imagePullPolicy: {{ .Values.invokerImagePullPolicy | quote }}
-        image: {{ .Values.invokerImage | quote }}
+      - name: {{ .Values.invoker.name | quote }}
+        imagePullPolicy: {{ .Values.invoker.imagePullPolicy | quote }}
+        image: {{ .Values.invoker.image | quote }}
         command: [ "/bin/bash", "-c", "COMPONENT_NAME=$(hostname | cut -d'-' -f2) /init.sh"]
-        resources:
-          requests:
-            memory: "100Mi"
-            cpu: "0.1"
         env:
           - name: "PORT"
             value: "8080"
@@ -88,7 +84,7 @@ spec:
 
           # Invoker options
           - name: "INVOKER_OPTS"
-            value: {{ .Values.invokerOptions | quote }}
+            value: {{ .Values.invoker.options | quote }}
 
           # action runtimes
           - name: "RUNTIMES_MANIFEST"
@@ -107,11 +103,11 @@ spec:
 
           # properties for kafka connection
           - name: "KAFKA_HOSTS"
-            value: "{{ .Values.kafka.serviceName }}.{{ .Release.Namespace }}:{{ .Values.kafka.port }}"
+            value: "{{ .Values.kafka.name }}.{{ .Release.Namespace }}:{{ .Values.kafka.port }}"
 
           # properties for zookeeper connection
           - name: "ZOOKEEPER_HOSTS"
-            value: "{{ .Values.zookeeper.serviceName }}.{{ .Release.Namespace }}:{{ .Values.zookeeper.port  }}"
+            value: "{{ .Values.zookeeper.name }}.{{ .Release.Namespace }}:{{ .Values.zookeeper.port  }}"
 
         ports:
         - name: invoker

--- a/helm/templates/kafka.yaml
+++ b/helm/templates/kafka.yaml
@@ -1,40 +1,40 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.kafka.serviceName | quote }}
+  name: {{ .Values.kafka.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   ports:
   - name: broker
     port: {{ .Values.kafka.port }}
   selector:
-    app: {{ .Values.kafka.statefulsetName | quote }}
+    app: {{ .Values.kafka.name | quote }}
 
 ---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: {{ .Values.kafka.statefulsetName | quote }}
+  name: {{ .Values.kafka.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  serviceName: {{ .Values.kafka.serviceName | quote }}
+  name: {{ .Values.kafka.name | quote }}
   replicas: {{ .Values.kafka.replicaCount }}
   template:
     metadata:
       labels:
-        app: {{ .Values.kafka.statefulsetName | quote }}
+        app: {{ .Values.kafka.name | quote }}
     spec:
       {{- if .Values.affinity.enabled }}
       affinity:
 {{ include "affinity.controlPlane" . | indent 8 }}
-{{ include "affinity.selfAntiAffinity" ( .Values.kafka.statefulsetName | quote ) | indent 8 }}
+{{ include "affinity.selfAntiAffinity" ( .Values.kafka.name | quote ) | indent 8 }}
       {{- end }}
 
       initContainers:
 {{ include "readiness.waitForZookeeper" . | indent 6 }}
 
       containers:
-      - name: {{ .Values.kafka.statefulsetName | quote }}
+      - name: {{ .Values.kafka.name | quote }}
         image: {{ .Values.kafka.image | quote }}
         imagePullPolicy: {{ .Values.kafka.imagePullPolicy | quote }}
         ports:
@@ -44,7 +44,7 @@ spec:
         - name: "KAFKA_BROKER_ID"
           value: "0"
         - name: "KAFKA_ADVERTISED_HOST_NAME"
-          value: {{ .Values.kafka.statefulsetName | quote }}
+          value: {{ .Values.kafka.name | quote }}
         - name: "KAFKA_ADVERTISED_PORT"
           value: "{{ .Values.kafka.port }}"
         - name: "KAFKA_HOST_NAME"

--- a/helm/templates/nginx.yaml
+++ b/helm/templates/nginx.yaml
@@ -1,39 +1,30 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.nginx.serviceName | quote }}
+  name: {{ .Values.nginx.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    name: {{ .Values.nginx.serviceName | quote }}
+    name: {{ .Values.nginx.name | quote }}
 spec:
   type: NodePort
   selector:
-    name: {{ .Values.nginx.deploymentName | quote }}
+    name: {{ .Values.nginx.name | quote }}
   ports:
     - port: {{ .Values.nginx.httpPort }}
-      targetPort: {{ .Values.nginx.httpPort }}
-      {{- if .Values.nginx.httpNodePort }}
-      nodePort: {{ .Values.nginx.httpNodePort }}
-      {{- end }}
       name: http
     - port: {{ .Values.nginx.httpsPort }}
-      targetPort: {{ .Values.nginx.httpsPort }}
       {{- if .Values.nginx.httpsNodePort }}
       nodePort: {{ .Values.nginx.httpsNodePort }}
       {{- end }}
       name: https-api
     - port: {{ .Values.nginx.httpsAdminPort }}
-      targetPort: {{ .Values.nginx.httpsAdminPort }}
-      {{- if .Values.nginx.httpsAdminNodePort }}
-      nodePort: {{ .Values.nginx.httpsAdminNodePort }}
-      {{- end }}
       name: https-admin
 
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Values.nginx.deploymentName | quote }}
+  name: {{ .Values.nginx.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     name: nginx
@@ -42,28 +33,28 @@ spec:
   template:
     metadata:
       labels:
-        name: {{ .Values.nginx.deploymentName | quote }}
+        name: {{ .Values.nginx.name | quote }}
     spec:
-      restartPolicy: Always
+      restartPolicy: {{ .Values.nginx.restartPolicy }}
 
       {{- if .Values.affinity.enabled }}
       affinity:
 {{ include "affinity.controlPlane" . | indent 8 }}
-{{ include "affinity.selfAntiAffinity" ( .Values.nginx.deploymentName | quote ) | indent 8 }}
+{{ include "affinity.selfAntiAffinity" ( .Values.nginx.name | quote ) | indent 8 }}
       {{- end }}
 
       volumes:
       - name: nginx-certs
         secret:
-          secretName: {{ .Values.nginx.secretName | quote }}
+          secretName: {{ .Values.nginx.name | quote }}
       - name: nginx-conf
         configMap:
-          name: {{ .Values.nginx.configmapName | quote }}
+          name: {{ .Values.nginx.name | quote }}
       - name: logs
         emptyDir: {}
 
       containers:
-      - name: {{ .Values.nginx.deploymentName | quote }}
+      - name: {{ .Values.nginx.name | quote }}
         imagePullPolicy: {{ .Values.nginx.imagePullPolicy | quote }}
         image: {{ .Values.nginx.image | quote }}
         ports:

--- a/helm/templates/nginx_configmap.yaml
+++ b/helm/templates/nginx_configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.nginx.configmapName | quote }}
+  name: {{ .Values.nginx.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
 data:
   nginx.conf: |

--- a/helm/templates/nginx_secret.yaml
+++ b/helm/templates/nginx_secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.nginx.secretName | quote }}
+  name: {{ .Values.nginx.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
 type: tls
 data:

--- a/helm/templates/zookeeper.yaml
+++ b/helm/templates/zookeeper.yaml
@@ -1,49 +1,46 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.zookeeper.serviceName | quote }}
+  name: {{ .Values.zookeeper.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    name: {{ .Values.zookeeper.serviceName | quote }}
+    name: {{ .Values.zookeeper.name | quote }}
 spec:
   selector:
-    name: {{ .Values.zookeeper.deploymentName | quote }}
+    name: {{ .Values.zookeeper.name | quote }}
   ports:
     - port: {{ .Values.zookeeper.port }}
-      targetPort: {{ .Values.zookeeper.port }}
       name: "zookeeper"
     - port: {{ .Values.zookeeper.serverPort }}
-      targetPort: {{ .Values.zookeeper.serverPort }}
       name: "server"
     - port: {{ .Values.zookeeper.leaderElectionPort }}
-      targetPort: {{ .Values.zookeeper.leaderElectionPort }}
       name: "leader-election"
 
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Values.zookeeper.deploymentName | quote }}
+  name: {{ .Values.zookeeper.name | quote }}
   namespace: {{ .Release.Namespace | quote}}
   labels:
-    name: {{ .Values.zookeeper.deploymentName | quote }}
+    name: {{ .Values.zookeeper.name | quote }}
 spec:
   replicas: {{ .Values.zookeeper.replicaCount }}
   template:
     metadata:
       labels:
-        name: {{ .Values.zookeeper.deploymentName | quote }}
+        name: {{ .Values.zookeeper.name | quote }}
     spec:
       restartPolicy: {{ .Values.zookeeper.restartPolicy | quote }}
 
       {{- if .Values.affinity.enabled }}
       affinity:
 {{ include "affinity.controlPlane" . | indent 8 }}
-{{ include "affinity.selfAntiAffinity" ( .Values.zookeeper.deploymentName | quote ) | indent 8 }}
+{{ include "affinity.selfAntiAffinity" ( .Values.zookeeper.name | quote ) | indent 8 }}
       {{- end }}
 
       containers:
-      - name: {{ .Values.zookeeper.containerName | quote }}
+      - name: {{ .Values.zookeeper.name | quote }}
         image: {{ .Values.zookeeper.image | quote }}
         imagePullPolicy: {{ .Values.zookeeper.imagePullPolicy | quote }}
         ports:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,6 +1,4 @@
 # Default values for OpenWhisk.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
 
 # Overall system configuration
 whisk:
@@ -20,33 +18,31 @@ travis: false
 
 # zookeeper configurations
 zookeeper:
-  deploymentName: "zookeeper"
-  serviceName: "zookeeper"
-  replicaCount: 1
-  restartPolicy: "Always"
-  containerName: "zookeeper"
+  name: "zookeeper"
   image: "zookeeper:3.4"
+  replicaCount: 1
   imagePullPolicy: "IfNotPresent"
+  restartPolicy: "Always"
   port: 2181
   serverPort: 2888
   leaderElectionPort: 3888
 
 # kafka configurations
 kafka:
-  serviceName: "kafka"
-  statefulsetName: "kafka"
-  replicaCount: 1
+  name: "kafka"
   image: "wurstmeister/kafka:0.11.0.1"
+  replicaCount: 1
   imagePullPolicy: "IfNotPresent"
+  restartPolicy: "Always"
   port: 9092
 
 # Database configuration
 db:
-  deploymentName: "couchdb"
-  serviceName: "couchdb"
+  name: "couchdb"
+  image: "openwhisk/kube-couchdb"
   replicaCount: 1
   imagePullPolicy: "IfNotPresent"
-  image: "openwhisk/kube-couchdb"
+  restartPolicy: "Always"
   port: 5984
   auth:
     username: "whisk_admin"
@@ -64,27 +60,23 @@ db:
 
 # Nginx configurations
 nginx:
-  secretName: "nginx"
-  configmapName: "nginx"
-  deploymentName: "nginx"
-  replicaCount: 1
+  name: "nginx"
   image: "nginx:1.11"
+  replicaCount: 1
   imagePullPolicy: "IfNotPresent"
+  restartPolicy: "Always"
   httpPort: 80
-  httpNodePort: 31000
   httpsPort: 443
   httpsNodePort: 31001
   httpsAdminPort: 8443
-  httpsAdminNodePort: 31002
-  serviceName: "nginx"
 
 # Controller configurations
 controller:
-  serviceName: "controller"
-  statefulSetName: "controller"
+  name: "controller"
+  image: "openwhisk/controller"
   replicaCount: 1
   imagePullPolicy: "IfNotPresent"
-  image: "openwhisk/controller"
+  restartPolicy: "Always"
   port: 8080
   limits:
     actionsSequenceMaxlength: 50
@@ -97,20 +89,22 @@ controller:
   HA: false
 
 # Invoker configurations
-invokerDeploymentName: "invoker"
-invokerReplicasetCount: 1
-invokerImagePullPolicy: "IfNotPresent"
-invokerImage: "openwhisk/invoker"
-invokerOptions: ""
+invoker:
+  name: "invoker"
+  image: "openwhisk/invoker"
+  imagePullPolicy: "IfNotPresent"
+  restartPolicy: "Always"
+  options: ""
 
 # API Gateway configurations
-apigatewayImagePullPolicy: "IfNotPresent"
-apigatewayImage: "openwhisk/apigateway"
-apigatewayReplicaCount: 1
 apigw:
-  deploymentName: "apigateway"
-  serviceName: "apigateway"
+  name: "apigateway"
+  image: "openwhisk/apigateway"
+  replicaCount: 1
+  imagePullPolicy: "IfNotPresent"
+  restartPolicy: "Always"
   apiPort: 9000
+  apiNodePort: 31004
   mgmtPort: 8080
 
 # Resolve the pod/node affinity for invoker, controller and other components.


### PR DESCRIPTION
Make a pass through values.yaml to unify naming conventions and
group into per-service hierarchies.  Inline trivial helper templates
and apply a number of small fixups to the yaml files.