### PR TITLE
Kuberentes v1.9.7 Deployment

### DIFF
--- a/kubernetes/apigateway/apigateway.yml
+++ b/kubernetes/apigateway/apigateway.yml
@@ -49,12 +49,23 @@ spec:
                   values:
                   - apigateway
             topologyKey: "kubernetes.io/hostname"
-
       volumes:
       - name: redis-data
         persistentVolumeClaim:
           claimName: pv-apigateway-01
-
+      initContainers:
+      - name: redis-init
+        image: busybox
+        command:
+          - chown
+          - -v
+          - -R
+          - 999:999
+          - /data
+        volumeMounts:
+        - mountPath: /data
+          name: redis-data
+          readOnly: false
       containers:
       - name: redis
         imagePullPolicy: IfNotPresent
@@ -62,6 +73,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: redis-data
+          readOnly: false
       - name: apigateway
         imagePullPolicy: Always
         image: openwhisk/apigateway


### PR DESCRIPTION
I have been trough the documentation to install OpenWhisk in Kubernetes, and on newest version I found a couple of items to be improved in documentation and Kubernetes definitions:

- Before installing the `ApiGateway`, `CouchDB` needs to be present;
- Changing `Redis` mount point to it's own UID/GID;