### PR TITLE
replicated controllers via k8s-based akka cluster discovery

### DIFF
--- a/helm/templates/controller.yaml
+++ b/helm/templates/controller.yaml
@@ -31,6 +31,7 @@ spec:
       labels:
         name: {{ .Values.controller.name | quote }}
     spec:
+      serviceAccountName: ow-core
       restartPolicy: {{ .Values.controller.restartPolicy }}
 
       {{- if .Values.affinity.enabled }}
@@ -52,6 +53,10 @@ spec:
         ports:
         - name: controller
           containerPort: {{ .Values.controller.port }}
+        - name: akka-remoting
+          containerPort: 2552
+        - name: akka-mgmt-http
+          containerPort: 19999
         livenessProbe:
           httpGet:
             path: "/ping"
@@ -111,11 +116,17 @@ spec:
 
         - name: "CONTROLLER_INSTANCES"
           value: {{ .Values.controller.replicaCount | quote }}
-        - name: "CONTROLLER_LOCALBOOKKEEPING"
-          value: {{ .Values.controller.localbookkeeping | quote }}
-        - name: "AKKA_CLUSTER_SEED_NODES"
-          value: {{ .Values.controller.seedNodes | quote }}
-        - name: "CONTROLLER_HA"
-          value: {{ .Values.controller.HA | quote }}
+{{- if gt (int .Values.controller.replicaCount) 1 }}
+        - name: "CONFIG_whisk_cluster_useClusterBootstrap"
+          value: "true"
         - name: "CONFIG_akka_actor_provider"
           value: "cluster"
+        - name: "CONFIG_akka_discovery_method"
+          value: "kubernetes-api"
+        - name: "CONFIG_akka_discovery_kubernetesApi_podNamespace"
+          value: {{ .Release.Namespace | quote }}
+        - name: "CONFIG_akka_discovery_kubernetesApi_podLabelSelector"
+          value: "name={{ .Values.controller.name }}"
+        - name: "CONFIG_akka_discovery_kubernetesApi_podPortName"
+          value: "akka-mgmt-http"
+{{- end }}

--- a/helm/templates/rolebindings.yaml
+++ b/helm/templates/rolebindings.yaml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+# Core pods are allowed to have view access to k8s APIs
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: ow-core
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-view
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: ow-core
+    namespace: {{ .Release.Namespace | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -87,9 +87,6 @@ controller:
     actionsInvokesPerminute: 60
     actionsInvokesConcurrentinsystem: 5000
     actionsInvokesConcurrent: 30
-  localbookkeeping: true
-  seedNodes: "[]"
-  HA: false
 
 # Invoker configurations
 invoker:


### PR DESCRIPTION
Enable kubernetes API based cluster discovery for controllers.
Multiple controllers can now be enabled in a Helm-based deploy
simply by setting controller.replicaCount to a value > 1.