### PR TITLE
Small change to make persistent-volumes work in GKE

### DIFF
--- a/kubernetes/cluster-setup/persistent-volumes.yml
+++ b/kubernetes/cluster-setup/persistent-volumes.yml
@@ -9,6 +9,7 @@ metadata:
     pv-owner: openwhisk
     pv-usage: pv-apigateway
 spec:
+  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   capacity:
@@ -22,6 +23,7 @@ metadata:
   name: pv-apigateway-01
   namespace: openwhisk
 spec:
+  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   resources:
@@ -40,6 +42,7 @@ metadata:
     pv-owner: openwhisk
     pv-usage: pv-couchdb
 spec:
+  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   capacity:
@@ -53,6 +56,7 @@ metadata:
   name: pv-couchdb-01
   namespace: openwhisk
 spec:
+  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   resources:
@@ -72,6 +76,7 @@ metadata:
     pv-owner: openwhisk
     pv-usage: pv-kafka
 spec:
+  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   capacity:
@@ -85,6 +90,7 @@ metadata:
   name: pv-kafka-01
   namespace: openwhisk
 spec:
+  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   resources:
@@ -104,6 +110,7 @@ metadata:
     pv-owner: openwhisk
     pv-usage: pv-zookeeper-data
 spec:
+  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   capacity:
@@ -117,6 +124,7 @@ metadata:
   name: pv-zookeeper-data-01
   namespace: openwhisk
 spec:
+  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   resources:
@@ -134,6 +142,7 @@ metadata:
     pv-owner: openwhisk
     pv-usage: pv-zookeeper-datalog
 spec:
+  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   capacity:
@@ -147,6 +156,7 @@ metadata:
   name: pv-zookeeper-datalog-01
   namespace: openwhisk
 spec:
+  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
added spec: storageClassName: manual
to PV and PVC to make them work in GKE

Otherwise GKE can not bind them together and PVC keeps waiting forever for a matching PV.
I think it's a bug in GKE, this is just a workaround but I think it's useful for compatibility