### PR TITLE
Document persistent volumes and use of external db

### DIFF
--- a/docs/configurationChoices.md
+++ b/docs/configurationChoices.md
@@ -36,6 +36,53 @@ controller:
   replicaCount: 2
 ```
 
+### Using an external database
+
+You may want to use an external CouchDB or Cloudant instance instead
+of deploying a CouchDB instance as a Kubernetes pod.  You can do this
+by adding a stanza like the one below to your `mycluster.yaml`,
+substituting in the appropriate values for `<...>`
+```yaml
+db:
+  external: true
+  host: <db hostname or ip addr>
+  port: <db port>
+  protocol: <"http" or "https">
+  auth:
+    username: <username>
+    password: <password>
+```
+
+Note that if you use an external database, the Helm deployment process
+will not attempt to create the necessary database tables or otherwise
+initialize/wipe the database.  You will need to properly initialize
+your external database before deploying the OpenWhisk chart.
+
+### Persistence
+
+The couchdb, zookeeper, kafka, and redis microservices can each be
+configured to use persistent volumes to store their data. Enabling
+persistence may allow the system to survive failures/restarts of these
+components without a complete loss of application state. By default,
+none of these services is configured to use persistent volumes.  To
+enable persistence, you can add stanzas like the following to your
+`mycluster.yaml` to enable persistence and to request an appropriately
+sized volume.
+
+```yaml
+redis:
+  persistence:
+    enabled: true
+    size: 256Mi
+    storageClass: default
+```
+If you are deploying on a managed Kubernetes cluster, check the cloud
+provider's documentation to determine the appropriate `storageClass`
+and `size` to request.
+
+*Limitation* Currently the persistent volume support assumes that the
+`replicaCount` of the deployment using the persistent volume is 1.
+
 ### Invoker Container Factory
 
 The Invoker is responsible for creating and managing the containers

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -13,7 +13,11 @@
 
 {{/* hostname for database */}}
 {{- define "db_host" -}}
+{{- if .Values.db.external -}}
+{{ .Values.db.host }}
+{{- else -}}
 {{ .Values.db.name }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
 {{- end -}}
 
 {{/* hostname for kafka */}}

--- a/helm/templates/_readiness.tpl
+++ b/helm/templates/_readiness.tpl
@@ -3,6 +3,9 @@
 
 {{/* Init container that waits for couchdb to be ready */}}
 {{- define "readiness.waitForCouchDB" -}}
+{{ if .Values.db.external }}
+# external db is assumed to be already ready; no need for init container
+{{- else -}}
 - name: "wait-for-couchdb"
   image: "busybox"
   imagePullPolicy: "IfNotPresent"
@@ -10,6 +13,7 @@
   - name: "READINESS_URL"
     value: {{ .Values.db.protocol }}://{{ include "db_host" . }}:{{ .Values.db.port }}/{{ .Values.db.activationsTable }}
   command: ["sh", "-c", "result=1; until [ $result -eq 0 ]; do echo verifying CouchDB readiness; wget -T 5 --spider $READINESS_URL; result=$?; sleep 1; done;"]
+{{- end -}}
 {{- end -}}
 
 {{/* Init container that waits for kafka to be ready */}}

--- a/helm/templates/couchdb.yaml
+++ b/helm/templates/couchdb.yaml
@@ -1,6 +1,7 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
+{{ if not .Values.db.external }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -100,3 +101,5 @@ spec:
     requests:
       storage: {{ .Values.db.persistence.size }}
 {{- end }}
+
+{{ end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,13 +1,29 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-# Default values for OpenWhisk.
 
-# Overall system configuration
+# This file defines the default values for all variables
+# used in the OpenWhisk Helm Chart.  The variables are grouped
+# by component into subtrees.
+#
+# You _MUST_ override the default values of whisk.ingress.api_host_name
+# and whisk.ingress.api_host_port (see docs/ingress.md for a discussion
+# of how to determine values for these variables).
+#
+# Production deployments _MUST_ override the default credentials
+# that are used in whisk.auth and db.auth.
+#
+# The file docs/configurationChoices.md discusses other common
+# configuration options for OpenWhisk and which variables to override
+# to enable them.
+
+
+# Overall configuration of the deployment
 whisk:
+  # Ingress defines how to access OpenWhisk from outside the Kubernetes cluster.
+  # See docs/ingress.md for a discussion of how to provide these values.
   ingress:
     name: "ow-ingress"
-    # You _MUST_ provide a value for whisk.ingress.api_host_name and api_host_port when deploying the chart
     api_host_name: nil
     api_host_port: nil
     api_host_proto: "https"
@@ -66,14 +82,17 @@ kafka:
 
 # Database configuration
 db:
+  external: false
   name: "couchdb"
   image: "openwhisk/kube-couchdb:latest"
   replicaCount: 1
   imagePullPolicy: "IfNotPresent"
   restartPolicy: "Always"
+  host: nil
   port: 5984
   provider: "CouchDB"
   protocol: "http"
+  # Production deployments _MUST_ override the default user/password values
   auth:
     username: "whisk_admin"
     password: "some_passw0rd"
@@ -169,7 +188,10 @@ redis:
     storageClass: default
     accessMode: ReadWriteOnce
 
-# Resolve the pod/node affinity for invoker, controller and other components.
+# Used to define pod affinity and anti-affinity for the Kubernetes scheduler.
+# If affinity.enabled is true, then all of the deployments for the OpenWhisk
+# microservices will use node and pod affinity directives to inform the
+# scheduler how to best distribute the pods on the available nodes in the cluster.
 affinity:
   enabled: true
   coreNodeLabel: core


### PR DESCRIPTION
1. Add support for using an external database and document it.
2. Document support for using persistent volumes.