### PR TITLE
Bug fix for issue #230 (zookeeper volume mount)

### DIFF
--- a/helm/templates/zookeeper.yaml
+++ b/helm/templates/zookeeper.yaml
@@ -68,7 +68,7 @@ spec:
         - mountPath: /data
           name: zk-data
         - mountPath: /datalog
-          name: zk-data
+          name: zk-datalog
 {{- end }}
         env:
 {{- if .Values.zookeeper.persistence.enabled }}

--- a/kubernetes/zookeeper/zookeeper.yml
+++ b/kubernetes/zookeeper/zookeeper.yml
@@ -71,7 +71,7 @@ spec:
         - mountPath: /data
           name: zk-data
         - mountPath: /datalog
-          name: zk-data
+          name: zk-datalog
         env:
         - name: "ZOO_DATA_DIR"
           value: /data


### PR DESCRIPTION
Due to a typo in the pod specification, we were incorrectly mounting
the zk-data volume twice and not mounting the zk-datalog volume at
all.  This resulted on zookeeper crashing after restart because log
data had been written to the data directory.

Fixes #230.