### PR TITLE
Update for upstream move of version info to PureConfig

### DIFF
--- a/helm/templates/controller.yaml
+++ b/helm/templates/controller.yaml
@@ -69,12 +69,10 @@ spec:
         - name: "PORT"
           value: {{ .Values.controller.port | quote }}
 
-        - name:  "WHISK_VERSION_DATE"
+        - name:  "CONFIG_whisk_info_date"
           value: {{ dateInZone "2006-01-02-03:04:05Z" (now) "UTC"| quote }}
-        - name: "WHISK_VERSION_BUILDNO"
+        - name: "CONFIG_whisk_info_buildNo"
           value: {{ .Values.whisk.versions.tag | quote }}
-        - name: "WHISK_VERSION_NAME"
-          value: {{ .Values.whisk.versions.name | quote }}
 
         # Java options
         - name: "JAVA_OPTS"

--- a/helm/templates/invoker.yaml
+++ b/helm/templates/invoker.yaml
@@ -113,7 +113,7 @@ spec:
             value: ""
 
           # this version is the day it is deployed,
-          - name:  "WHISK_VERSION_DATE"
+          - name:  "CONFIG_whisk_info_date"
             value: {{ dateInZone "2006-01-02-03:04:05Z" (now) "UTC"| quote }}
 
           # properties for DB connection

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -32,7 +32,6 @@ whisk:
     system: "789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP"
     guest: "23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP"
   versions:
-    name: "OpenWhisk"
     tag: "latest"
     cli: "latest"
   systemNameSpace: "/whisk.system"


### PR DESCRIPTION
Update Helm chart for upstream PR 3617 that eliminated
whisk_version name and moved the version number and date
to PureConfig.