### PR TITLE
store key OpenWhisk configuration values in ConfigMaps

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -53,17 +53,35 @@
       name: db.auth
       key: db_password
 - name: "CONFIG_whisk_couchdb_port"
-  value: {{ .Values.db.port | quote}}
+  valueFrom:
+    configMapKeyRef:
+      name: db.config
+      key: db_port
 - name: "CONFIG_whisk_couchdb_protocol"
-  value: {{ .Values.db.protocol | quote }}
+  valueFrom:
+    configMapKeyRef:
+      name: db.config
+      key: db_protocol
 - name: "CONFIG_whisk_couchdb_host"
   value: {{ include "db_host" . | quote }}
 - name: "CONFIG_whisk_couchdb_provider"
-  value: {{ .Values.db.provider | quote }}
+  valueFrom:
+    configMapKeyRef:
+      name: db.config
+      key: db_provider
 - name: "CONFIG_whisk_couchdb_databases_WhiskActivation"
-  value: {{ .Values.db.activationsTable | quote }}
+  valueFrom:
+    configMapKeyRef:
+      name: db.config
+      key: db_whisk_activations
 - name: "CONFIG_whisk_couchdb_databases_WhiskEntity"
-  value: {{ .Values.db.actionsTable | quote }}
+  valueFrom:
+    configMapKeyRef:
+      name: db.config
+      key: db_whisk_actions
 - name: "CONFIG_whisk_couchdb_databases_WhiskAuth"
-  value: {{ .Values.db.authsTable | quote }}
+  valueFrom:
+    configMapKeyRef:
+      name: db.config
+      key: db_whisk_auths
 {{- end -}}

--- a/helm/templates/apigateway.yaml
+++ b/helm/templates/apigateway.yaml
@@ -56,4 +56,7 @@ spec:
           - name: "REDIS_PORT"
             value: {{ .Values.redis.port | quote }}
           - name: "PUBLIC_GATEWAY_URL"
-            value: "{{- .Values.whisk.ingress.api_host_proto -}}://{{- .Values.whisk.ingress.api_host_name -}}:{{- .Values.whisk.ingress.api_host_port -}}"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_api_host_url

--- a/helm/templates/clusterConfigMaps.yaml
+++ b/helm/templates/clusterConfigMaps.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: whisk.config
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  whisk_info_date: {{ dateInZone "2006-01-02-03:04:05Z" (now) "UTC"| quote }}
+  whisk_info_buildNo: {{ .Values.whisk.versions.tag | quote }}
+  whisk_cli_version_tag: {{ .Values.whisk.versions.cli | quote }}
+  whisk_system_namespace: {{ .Values.whisk.systemNameSpace | quote }}
+  whisk_api_host_proto: {{ .Values.whisk.ingress.api_host_proto | quote }}
+  whisk_api_host_port: {{ .Values.whisk.ingress.api_host_port | quote }}
+  whisk_api_host_name: {{ .Values.whisk.ingress.api_host_name | quote }}
+  whisk_api_host_nameAndPort: "{{ .Values.whisk.ingress.api_host_name }}:{{ .Values.whisk.ingress.api_host_port }}"
+  whisk_api_host_url: "{{ .Values.whisk.ingress.api_host_proto }}://{{ .Values.whisk.ingress.api_host_name }}:{{ .Values.whisk.ingress.api_host_port }}"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db.config
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  db_prefix: {{ .Values.db.dbPrefix | quote }}
+  db_protocol: {{ .Values.db.protocol | quote }}
+  db_provider: {{ .Values.db.provider | quote }}
+  db_host: {{ include "db_host" . | quote }}
+  db_port: {{ .Values.db.port | quote }}
+  db_url: "{{ .Values.db.protocol }}://{{ include "db_host" . }}:{{ .Values.db.port }}"
+  db_whisk_actions: {{ .Values.db.actionsTable | quote }}
+  db_whisk_activations: {{ .Values.db.activationsTable | quote }}
+  db_whisk_auths: {{ .Values.db.authsTable | quote }}

--- a/helm/templates/controller.yaml
+++ b/helm/templates/controller.yaml
@@ -70,9 +70,15 @@ spec:
           value: {{ .Values.controller.port | quote }}
 
         - name:  "CONFIG_whisk_info_date"
-          value: {{ dateInZone "2006-01-02-03:04:05Z" (now) "UTC"| quote }}
+          valueFrom:
+            configMapKeyRef:
+              name: whisk.config
+              key: whisk_info_date
         - name: "CONFIG_whisk_info_buildNo"
-          value: {{ .Values.whisk.versions.tag | quote }}
+          valueFrom:
+            configMapKeyRef:
+              name: whisk.config
+              key: whisk_info_date
 
         # Java options
         - name: "JAVA_OPTS"

--- a/helm/templates/couchdb.yaml
+++ b/helm/templates/couchdb.yaml
@@ -51,7 +51,10 @@ spec:
         - name: "DB_HOST"
           value: "127.0.0.1"
         - name: "DB_PREFIX"
-          value: {{ .Values.db.dbPrefix | quote }}
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_prefix
         - name: "COUCHDB_USER"
           valueFrom:
             secretKeyRef:
@@ -63,7 +66,10 @@ spec:
               name: db.auth
               key: db_password
         - name: "DB_PORT"
-          value: {{ .Values.db.port | quote }}
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_port
         - name: "NODENAME"
           value: "couchdb0"
         readinessProbe:

--- a/helm/templates/installCatalogJob.yaml
+++ b/helm/templates/installCatalogJob.yaml
@@ -21,7 +21,10 @@ spec:
         image: openwhisk/kube-openwhisk-catalog
         env:
           - name: "WHISK_CLI_VERSION"
-            value: {{ .Values.whisk.versions.cli | quote }}
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_cli_version_tag
           - name: "WHISK_AUTH"
             valueFrom:
               secretKeyRef:
@@ -29,4 +32,7 @@ spec:
                 key: system
           # poorly named envvar; actually expects full apihost (host:port)
           - name: "WHISK_API_HOST_NAME"
-            value: "{{- .Values.whisk.ingress.api_host_name -}}:{{- .Values.whisk.ingress.api_host_port -}}"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_api_host_nameAndPort

--- a/helm/templates/installPkgKafkaJob.yaml
+++ b/helm/templates/installPkgKafkaJob.yaml
@@ -27,12 +27,21 @@ spec:
                 key: system
           # poorly named envvar; actually expects full apihost (host:port)
           - name: "APIHOST"
-            value: "{{- .Values.whisk.ingress.api_host_name -}}:{{- .Values.whisk.ingress.api_host_port -}}"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_api_host_nameAndPort
           # for the database used by kafka package
           - name: "DB_HOST"
-            value: {{ include "db_host" . | quote }}
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_host
           - name: "DB_PORT"
-            value: {{ .Values.db.port | quote}}
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_port
           - name: "DB_USERNAME"
             valueFrom:
               secretKeyRef:

--- a/helm/templates/installRouteMgmtJob.yaml
+++ b/helm/templates/installRouteMgmtJob.yaml
@@ -21,7 +21,10 @@ spec:
         image: openwhisk/kube-routemgmt
         env:
           - name: "WHISK_CLI_VERSION"
-            value: {{ .Values.whisk.versions.cli | quote }}
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_cli_version_tag
           - name: "WHISK_AUTH"
             valueFrom:
               secretKeyRef:
@@ -29,8 +32,14 @@ spec:
                 key: system
           # poorly named envvar; actually expects full apihost (host:port)
           - name: "WHISK_API_HOST_NAME"
-            value: "{{- .Values.whisk.ingress.api_host_name -}}:{{- .Values.whisk.ingress.api_host_port -}}"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_api_host_nameAndPort
           - name: "WHISK_NAMESPACE"
-            value: {{ .Values.whisk.systemNameSpace | quote }}
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_system_namespace
           - name: "WHISK_API_GATEWAY_HOST_V2"
             value: "http://$(APIGATEWAY_SERVICE_HOST):$(APIGATEWAY_SERVICE_PORT_API)/v2"

--- a/helm/templates/invoker.yaml
+++ b/helm/templates/invoker.yaml
@@ -59,12 +59,20 @@ spec:
 
           # Needed by invoker to set the environment variable __OW_API_HOST in action containers
           - name: "WHISK_API_HOST_PROTO"
-            value: {{ .Values.whisk.ingress.api_host_proto | quote }}
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_api_host_proto
           - name: "WHISK_API_HOST_PORT"
-            value: {{ .Values.whisk.ingress.api_host_port | quote }}
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_api_host_port
           - name: "WHISK_API_HOST_NAME"
-            value: {{ .Values.whisk.ingress.api_host_name | quote }}
-
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_api_host_name
           - name: "INVOKER_CONTAINER_NETWORK"
             value: {{ .Values.invoker.containerNetwork | quote }}
           - name: "CONFIG_whisk_docker_containerFactory_useRunc"
@@ -114,7 +122,10 @@ spec:
 
           # this version is the day it is deployed,
           - name:  "CONFIG_whisk_info_date"
-            value: {{ dateInZone "2006-01-02-03:04:05Z" (now) "UTC"| quote }}
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_info_date
 
           # properties for DB connection
 {{ include "whisk.dbEnvVars" . | indent 10 }}

--- a/helm/templates/pkgKafkaProvider.yaml
+++ b/helm/templates/pkgKafkaProvider.yaml
@@ -29,7 +29,10 @@ spec:
           containerPort: {{ .Values.kafkaprovider.apiPort }}
         env:
         - name: "DB_URL"
-          value: "{{ .Values.db.protocol }}://{{ include "db_host" . }}:{{ .Values.db.port }}"
+          valueFrom:
+            configMapKeyRef:
+              name: db.config
+              key: db_url
         - name: "DB_USER"
           valueFrom:
             secretKeyRef:
@@ -45,6 +48,12 @@ spec:
         - name: "LOCAL_DEV"
           value: "true"
         - name: "ROUTER_HOST"
-          value: "{{- .Values.whisk.ingress.api_host_name -}}:{{- .Values.whisk.ingress.api_host_port -}}"
+          valueFrom:
+            configMapKeyRef:
+              name: whisk.config
+              key: whisk_api_host_nameAndPort
         - name: "ENDPOINT_AUTH"
-          value: "{{- .Values.whisk.ingress.api_host_name -}}:{{- .Values.whisk.ingress.api_host_port -}}"
+          valueFrom:
+            configMapKeyRef:
+              name: whisk.config
+              key: whisk_api_host_nameAndPort


### PR DESCRIPTION
Go back to using ConfigMaps to store key cluster and database
configuration parameters and modify deployments to access the data
from those maps. Having explicit config maps makes it easier to
inspect the cluster configuration and enable separating the core
system and the providers into separate charts (subsequent PR after
this is merged).

Note: database and system authentication information continues to
be stored in secrets; that is unchanged by this PR.