### PR TITLE
External zookeeper kafka

### DIFF
--- a/docs/configurationChoices.md
+++ b/docs/configurationChoices.md
@@ -68,6 +68,35 @@ will not attempt to create the necessary database tables or otherwise
 initialize/wipe the database.  You will need to properly initialize
 your external database before deploying the OpenWhisk chart.
 
+### Using external Kafka and Zookeeper services
+
+You may want to use an external Zookeeper or Kafka service.  You can do this
+by adding a stanza like the one below to your `mycluster.yaml`.
+```yaml
+kafka:
+  external: true
+zookeeper:
+  external: true
+```
+
+And then defining kafka_host, zookeeper_connect, and zookeeper_zero_host in your parent chart. e.g.
+```
+{{/* hostname for kafka */}}
+{{- define "kafka_host" -}}
+{{ template "kafka.serviceName" . }}
+{{- end -}}
+
+{{/* hostname for zookeeper */}}
+{{- define "zookeeper_connect" -}}
+{{ template "zookeeper.serviceName" . }}
+{{- end -}}
+
+{{/* zookeeper_zero_host required by openwhisk readiness check */}}
+{{- define "zookeeper_zero_host" -}}
+{{ template "zookeeper.serviceName" . }}
+{{- end -}}
+```
+
 ### Persistence
 
 The couchdb, zookeeper, kafka, and redis microservices can each be

--- a/docs/configurationChoices.md
+++ b/docs/configurationChoices.md
@@ -70,8 +70,7 @@ your external database before deploying the OpenWhisk chart.
 
 ### Using external Kafka and Zookeeper services
 
-You may want to use an external Zookeeper or Kafka service.  You can do this
-by adding a stanza like the one below to your `mycluster.yaml`.
+You may want to use an external Zookeeper or Kafka service.  To disable the kafka and/or zookeeper with this chart, add a stanza like the one below to your `mycluster.yaml`.
 ```yaml
 kafka:
   external: true
@@ -79,7 +78,19 @@ zookeeper:
   external: true
 ```
 
-And then defining kafka_host, zookeeper_connect, and zookeeper_zero_host in your parent chart. e.g.
+To add the hostname of a pre-existing kafka and/or zookeeper, define it in `mycluster.yml` like this
+
+```yaml
+kafka:
+  external: true
+  name: < existing kafka service >
+zookeeper:
+  external: true
+  name: < existing zookeeper service >
+
+```
+
+Optionally, if including this chart as a dependency of another chart where kafka and zookeeper services are already included, disable this charts kafka and zookeeper as shown above and then define kafka_host, zookeeper_connect, and zookeeper_zero_host in your parent chart _helpers.tpl. e.g.
 ```
 {{/* hostname for kafka */}}
 {{- define "kafka_host" -}}

--- a/docs/configurationChoices.md
+++ b/docs/configurationChoices.md
@@ -90,7 +90,7 @@ zookeeper:
 
 ```
 
-Optionally, if including this chart as a dependency of another chart where kafka and zookeeper services are already included, disable this charts kafka and zookeeper as shown above and then define kafka_host, zookeeper_connect, and zookeeper_zero_host in your parent chart _helpers.tpl. e.g.
+Optionally, if including this chart as a dependency of another chart where kafka and zookeeper services are already defined, disable this chart's kafka and zookeeper as shown above, and then define kafka_host, zookeeper_connect, and zookeeper_zero_host in your parent chart _helpers.tpl. e.g.
 ```
 {{/* hostname for kafka */}}
 {{- define "kafka_host" -}}

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -22,7 +22,11 @@
 
 {{/* hostname for kafka */}}
 {{- define "kafka_host" -}}
+{{- if .Values.kafka.external -}}
+{{ .Values.kafka.host }}
+{{- else -}}
 {{ .Values.kafka.name }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
 {{- end -}}
 
 {{/* hostname for redis */}}
@@ -32,9 +36,13 @@
 
 {{/* client connection string for zookeeper cluster (server1:port server2:port ... serverN:port)*/}}
 {{- define "zookeeper_connect" -}}
+{{- if .Values.zookeeper.external -}}
+{{ .Values.zookeeper.connect }}
+{{- else -}}
 {{- $zkname := .Values.zookeeper.name }}
 {{- $zkport := .Values.zookeeper.port }}
 {{- range $i, $e := until (int .Values.zookeeper.replicaCount) -}}{{ if ne $i 0 }},{{ end }}{{ $zkname }}-{{ . }}.{{ $zkname }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $zkport }}{{ end }}
+{{- end -}}
 {{- end -}}
 
 {{/* host name for server.0 in zookeeper cluster */}}

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -23,7 +23,7 @@
 {{/* hostname for kafka */}}
 {{- define "kafka_host" -}}
 {{- if .Values.kafka.external -}}
-{{ .Values.kafka.host }}
+{{ .Values.kafka.name }}
 {{- else -}}
 {{ .Values.kafka.name }}.{{ .Release.Namespace }}.svc.cluster.local
 {{- end -}}
@@ -37,7 +37,7 @@
 {{/* client connection string for zookeeper cluster (server1:port server2:port ... serverN:port)*/}}
 {{- define "zookeeper_connect" -}}
 {{- if .Values.zookeeper.external -}}
-{{ .Values.zookeeper.connect }}
+{{ .Values.zookeeper.name }}
 {{- else -}}
 {{- $zkname := .Values.zookeeper.name }}
 {{- $zkport := .Values.zookeeper.port }}
@@ -47,8 +47,13 @@
 
 {{/* host name for server.0 in zookeeper cluster */}}
 {{- define "zookeeper_zero_host" -}}
+{{- if .Values.zookeeper.external -}}
+{{ .Values.zookeeper.name }}
+{{- else -}}
 {{ .Values.zookeeper.name }}-0.{{ .Values.zookeeper.name }}.{{ $.Release.Namespace }}.svc.cluster.local
 {{- end -}}
+{{- end -}}
+
 
 {{/* Runtimes manifest */}}
 {{- define "runtimes_manifest" -}}

--- a/helm/openwhisk/templates/kafka.yaml
+++ b/helm/openwhisk/templates/kafka.yaml
@@ -1,5 +1,6 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
+{{ if not .Values.kafka.external }}
 
 apiVersion: v1
 kind: Service
@@ -90,4 +91,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.kafka.persistence.size }}
+{{- end }}
 {{- end }}

--- a/helm/openwhisk/templates/zookeeper.yaml
+++ b/helm/openwhisk/templates/zookeeper.yaml
@@ -1,5 +1,6 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
+{{ if not .Values.zookeeper.external }}
 
 apiVersion: v1
 kind: Service
@@ -112,4 +113,5 @@ spec:
       resources:
         requests:
           storage: {{ .Values.zookeeper.persistence.size }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
These changes allow users to deploy OpenWhisk with an external zookeeper and kafka. 

If kafka and zookeeper are toggled off, you can either define their hostnames in `mycluster.yml`, or if included as a dependency in a parent chart, define kafka_host, zookeeper_connect, and zookeeper_zero_host in _helpers.tpl.