### PR TITLE
Correctly writing custom OpenWhisk authentication keys (for the guest…

### DIFF
--- a/helm/openwhisk/configMapFiles/initCouchDB/initdb.sh
+++ b/helm/openwhisk/configMapFiles/initCouchDB/initdb.sh
@@ -4,6 +4,10 @@
 # Clone OpenWhisk to get the ansible playbooks needed to initialize CouchDB
 git clone https://github.com/apache/incubator-openwhisk /openwhisk
 
+# overwriting auth.guest and auth.whisk.system files with custom defined keys
+echo "$WHISK_AUTH_GUEST" > /openwhisk/ansible/files/auth.guest
+echo "$WHISK_AUTH_SYSTEM" > /openwhisk/ansible/files/auth.whisk.system
+
 # generate db_local.ini so the ansible jobs know how to access the database
 pushd /openwhisk/ansible
     ansible-playbook -i environments/local setup.yml

--- a/helm/openwhisk/templates/initCouchDBJob.yaml
+++ b/helm/openwhisk/templates/initCouchDBJob.yaml
@@ -61,6 +61,16 @@ spec:
               key: db_password
         - name: "NODENAME"
           value: "couchdb0"
+        - name: "WHISK_AUTH_GUEST"
+          valueFrom:
+            secretKeyRef:
+              name: whisk.auth
+              key: guest
+        - name: "WHISK_AUTH_SYSTEM"
+          valueFrom:
+            secretKeyRef:
+              name: whisk.auth
+              key: system
 
 ---
 apiVersion: v1


### PR DESCRIPTION
… and whisk.system users) into the CouchDB database.

With this fix, custom auth keys that are defined in `values.yml` of the Helm chart (`whisk.auth.system` and `whisk.auth.guest`) are correctly applied and stored in the CouchDB database of OpenWhisk.

In the `initdb.sh` script, the `https://github.com/apache/incubator-openwhisk` git repository is cloned on line number 5. In this git repository, the auth keys for OpenWhisk are stored in the `ansible/files/auth.guest` and `ansible/files/auth.whisk.system` files. These files contain the default authentication keys.

I have added two lines to this shell script, that take the secret keys from Kubernetes containing the custom values defined in`values.yml` of the Helm chart. 