### PR TITLE
Use whisk.auth from secrets instead of the default auths in the git repo

### DIFF
--- a/helm/openwhisk/configMapFiles/initCouchDB/initdb.sh
+++ b/helm/openwhisk/configMapFiles/initCouchDB/initdb.sh
@@ -4,6 +4,11 @@
 # Clone OpenWhisk to get the ansible playbooks needed to initialize CouchDB
 git clone https://github.com/apache/incubator-openwhisk /openwhisk
 
+# Copy the secrets whisk.auth.guest and whisk.auth.system into the cloned tree
+# overwriting the default values we cloned from git
+cp -f /etc/whisk-auth/guest /openwhisk/ansible/files/auth.guest
+cp -f /etc/whisk-auth/system /openwhisk/ansible/files/auth.whisk.system
+
 # generate db_local.ini so the ansible jobs know how to access the database
 pushd /openwhisk/ansible
     ansible-playbook -i environments/local setup.yml

--- a/helm/openwhisk/templates/initCouchDBJob.yaml
+++ b/helm/openwhisk/templates/initCouchDBJob.yaml
@@ -19,6 +19,9 @@ spec:
       - name: task-dir
         configMap:
           name: init-couchdb
+      - name: whisk-auth
+        secret:
+          secretName: whisk.auth
       containers:
       - name: init-couchdb
         image: openwhisk/kube-whisk-ansible-runner
@@ -28,6 +31,8 @@ spec:
         - name: task-dir
           mountPath: "/task/initdb.sh"
           subPath: "initdb.sh"
+        - name: whisk-auth
+          mountPath: "/etc/whisk-auth"
         env:
         - name: "DB_PROTOCOL"
           valueFrom:


### PR DESCRIPTION
A modification of the fix suggested in PR#271 that mounts the whisk.auth
secrets in a volume instead of putting them environment variables.