### PR TITLE
bugfix in StatefulSet templates: use serviceName, not name

### DIFF
--- a/helm/openwhisk/templates/controller.yaml
+++ b/helm/openwhisk/templates/controller.yaml
@@ -24,9 +24,9 @@ metadata:
   labels:
     name: {{ .Values.controller.name | quote }}
 spec:
+  serviceName: {{ .Values.controller.name | quote }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.controller.replicaCount }}
-  name: {{ .Values.controller.name | quote }}
   template:
     metadata:
       labels:

--- a/helm/openwhisk/templates/kafka.yaml
+++ b/helm/openwhisk/templates/kafka.yaml
@@ -21,8 +21,8 @@ metadata:
   name: {{ .Values.kafka.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  serviceName: {{ .Values.kafka.name | quote }}
   podManagementPolicy: "Parallel"
-  name: {{ .Values.kafka.name | quote }}
   replicas: {{ .Values.kafka.replicaCount }}
   template:
     metadata:


### PR DESCRIPTION
Fixes #278.