### PR TITLE
enable node affinity for invoker-agent DaemonSet

### DIFF
--- a/helm/openwhisk/templates/invoker.yaml
+++ b/helm/openwhisk/templates/invoker.yaml
@@ -177,11 +177,8 @@ spec:
       restartPolicy: Always
       hostNetwork: true
 
-      # TODO: disabled affinity until user-action pods are
-      #       created by KubernetesContainerFacotry with the
-      #       same affinity rules.
-      #       Requires extension to upstream kube java client
-      #       run only on nodes labeled with openwhisk-role=invoker
+      affinity:
+{{ include "affinity.invoker" . | indent 8 }}
 
       volumes:
 {{ include "docker_volumes" . | indent 6 }}


### PR DESCRIPTION
Upstream PR 3963 enhanced the KubernetesContainerFactory to
create user action pods with the proper node affinity, therefore
we can now restrict the invokerAgent to only run on invoker nodes.