### PR TITLE
Enable external db for alarm and kafka provider

### DIFF
--- a/helm/openwhisk-providers/charts/ow-alarm/README.md
+++ b/helm/openwhisk-providers/charts/ow-alarm/README.md
@@ -21,11 +21,33 @@
 
 This chart is to deploy alarm provider and package to OpenWhisk on a Kubernetes using Helm.
 
-## Preconditions
+## Config a CouchDB instance
 
-Alarm package can only be successfully installed under these two preconditions:
-+ persistentvolumes (aka 'pv') is defined in the Kubernetes cluster. You can verify by `kubectl get pv`.
-+ Kubernetes DNS is used as the DNS server in action containers. In order to achieve it, you can set `KubernetesContainerFactory` as the [Invoker Container Factory](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/docs/configurationChoices.md#invoker-container-factory) in the Kubernetes cluster by adding below configuration in the `mycluster.yaml` when you deploy OpenWhisk with Helm:
+A CouchDB instance is required to save the event data. You can use the same CouchDB instance as part of the OpenWhisk deployment or you can use a different CouchDB instance. To use the same CouchDB instance as OpenWhisk, config `values.yaml` as:
+```
+db:
+  external: false
+  prefix: "alm"
+```
+To use a different CouchDB instance, config the database parameters in `value.yaml` as:
+```
+db:
+  external: true
+  prefix: "cldt"
+  host: "0.0.0.0"
+  port: 5984
+  protocol: "http"
+  username: "admin"
+  password: "secret"
+```
+
+## Config a persistentvolumes
+persistentvolumes (aka 'pv') is defined in the Kubernetes cluster. You can verify by `kubectl get pv`.
+
+## Enable action containers use Kubernetes DNS
+You need to enable action containers to use Kubernetes DNS when you want to use the same CouchDB instance as part of the OpenWhisk deployment to save event data.
+
+The easiest way to do this is to set `KubernetesContainerFactory` as the [Invoker Container Factory](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/docs/configurationChoices.md#invoker-container-factory) in the Kubernetes cluster by adding below configuration in the `mycluster.yaml` when you deploy OpenWhisk with Helm:
 ```
 # Invoker configurations
 invoker:

--- a/helm/openwhisk-providers/charts/ow-alarm/configMapFiles/myTask.sh
+++ b/helm/openwhisk-providers/charts/ow-alarm/configMapFiles/myTask.sh
@@ -11,7 +11,7 @@ apk add --update nodejs-npm
 
 git clone https://github.com/apache/incubator-openwhisk-package-alarms.git
 
-export DB_URL=http://$DB_USERNAME:$DB_PASSWORD@$DB_HOST:$DB_PORT
+export DB_URL=$DB_PROTOCOL://$DB_USERNAME:$DB_PASSWORD@$DB_HOST:$DB_PORT
 pushd /incubator-openwhisk-package-alarms
   ./installCatalog.sh $AUTH $APIHOST $DB_URL $DB_PREFIX $APIHOST
 popd

--- a/helm/openwhisk-providers/charts/ow-alarm/templates/installPkgAlarmJob.yaml
+++ b/helm/openwhisk-providers/charts/ow-alarm/templates/installPkgAlarmJob.yaml
@@ -37,12 +37,30 @@ spec:
               configMapKeyRef:
                 name: whisk.config
                 key: whisk_api_host_nameAndPort
+          {{- if .Values.alarmprovider.db.external }}
+          # Config database using the external cloudant instance
+          - name: "DB_PROTOCOL"
+            value: {{ .Values.alarmprovider.db.protocol | quote }}
+          - name: "DB_HOST"
+            value: {{ .Values.alarmprovider.db.host | quote }}
+          - name: "DB_USERNAME"
+            value: {{ .Values.alarmprovider.db.username | quote }}
+          - name: "DB_PASSWORD"
+            value: {{ .Values.alarmprovider.db.password | quote }}
+          - name: "DB_PORT"
+            value: {{ .Values.alarmprovider.db.port | quote }}
+          {{- else }}
           # for the database used by alarms package
           - name: "DB_HOST"
             valueFrom:
               configMapKeyRef:
                 name: db.config
                 key: db_host
+          - name: "DB_PROTOCOL"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_protocol
           - name: "DB_PORT"
             valueFrom:
               configMapKeyRef:
@@ -58,8 +76,9 @@ spec:
               secretKeyRef:
                 name: db.auth
                 key: db_password
+          {{ end }}
           - name: "DB_PREFIX"
-            value: "{{- .Values.alarmprovider.dbPrefix -}}"
+            value: "{{- .Values.alarmprovider.db.prefix -}}"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/helm/openwhisk-providers/charts/ow-alarm/templates/pkgAlarmProvider.yaml
+++ b/helm/openwhisk-providers/charts/ow-alarm/templates/pkgAlarmProvider.yaml
@@ -31,6 +31,17 @@ spec:
         - name: alarmprovider
           containerPort: {{ .Values.alarmprovider.apiPort }}
         env:
+        {{- if .Values.alarmprovider.db.external }}
+        # Config database using the external instance
+        - name: "DB_PROTOCOL"
+          value: {{ .Values.alarmprovider.db.protocol | quote }}
+        - name: "DB_HOST"
+          value: "{{ .Values.alarmprovider.db.host }}:{{ .Values.alarmprovider.db.port }}"
+        - name: "DB_USERNAME"
+          value: {{ .Values.alarmprovider.db.username | quote }}
+        - name: "DB_PASSWORD"
+          value: {{ .Values.alarmprovider.db.password | quote }}
+        {{- else }}
         - name: "DB_PROTOCOL"
           valueFrom:
             configMapKeyRef:
@@ -51,8 +62,9 @@ spec:
             secretKeyRef:
               name: db.auth
               key: db_password
+        {{- end }}
         - name: "DB_PREFIX"
-          value: "{{- .Values.alarmprovider.dbPrefix -}}"
+          value: "{{- .Values.alarmprovider.db.prefix -}}"
         - name: "ROUTER_HOST"
           valueFrom:
             configMapKeyRef:

--- a/helm/openwhisk-providers/charts/ow-alarm/values.yaml
+++ b/helm/openwhisk-providers/charts/ow-alarm/values.yaml
@@ -10,7 +10,15 @@ alarmprovider:
   imagePullPolicy: "Always"
   restartPolicy: "Always"
   apiPort: 8080
-  dbPrefix: "alm"
+  db:
+    external: false
+    prefix: "alm"
+    # Add below values if you are using external couchdb instance
+    # host: "10.10.10.10"
+    # port: 5984
+    # protocol: "http"
+    # username: "admin"
+    # password: "secret"
   persistence:
     pvcName: alarmprovider-pvc
     size: 1Gi

--- a/helm/openwhisk-providers/charts/ow-cloudant/README.md
+++ b/helm/openwhisk-providers/charts/ow-cloudant/README.md
@@ -21,9 +21,9 @@
 
 This chart is to deploy Cloudant provider and package to OpenWhisk on a Kubernetes using Helm.
 
-## Preconditions
+## Config a CouchDB instance
 
-+ A CouchDB instance is required to save the event data. You can use the same CouchDB instance or you can use a different CouchDB instance. To use the same CouchDB instance as OpenWhisk, config `values.yaml` as:
+A CouchDB instance is required to save the event data. You can use the same CouchDB instance as part of the OpenWhisk deployment or you can use a different CouchDB instance. To use the same CouchDB instance as OpenWhisk, config `values.yaml` as:
 ```
 db:
   external: false
@@ -40,8 +40,16 @@ db:
   username: "admin"
   password: "secret"
 ```
-+ persistentvolumes (aka 'pv') is required by this charter. You can verify by `kubectl get pv`.
-+ Action containers use Kubernetes DNS. The easiest way to do this is to use the `KubernetesContainerFactory` as the [Invoker Container Factory](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/docs/configurationChoices.md#invoker-container-factory) in the Kubernetes cluster by adding below configuration in the `mycluster.yaml` when you deploy OpenWhisk with Helm:
+
+## Config a persistentvolumes
+persistentvolumes (aka 'pv') is required by this charter. You can verify by `kubectl get pv`.
+
+## Enable action containers use Kubernetes DNS
+You need to enable action containers to use Kubernetes DNS under one of below conditions:
++ you use the same CouchDB instance as part of the OpenWhisk deployment to save event data;
++ you intend to use the Kubernetes DNS name to locate a CouchDB/Cloudant instance as the CouchDB/Cloudant event provider.
+
+The easiest way to do this is to use the `KubernetesContainerFactory` as the [Invoker Container Factory](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/docs/configurationChoices.md#invoker-container-factory) in the Kubernetes cluster by adding below configuration in the `mycluster.yaml` when you deploy OpenWhisk with Helm:
 ```
 # Invoker configurations
 invoker:

--- a/helm/openwhisk-providers/charts/ow-cloudant/values.yaml
+++ b/helm/openwhisk-providers/charts/ow-cloudant/values.yaml
@@ -13,7 +13,7 @@ cloudantprovider:
   db:
     external: false
     prefix: "cldt"
-    # Add below values if you are using external instance
+    # Add below values if you are using external couchdb instance
     # host: "10.10.10.10"
     # port: 5984
     # protocol: "http"

--- a/helm/openwhisk-providers/charts/ow-kafka/README.md
+++ b/helm/openwhisk-providers/charts/ow-kafka/README.md
@@ -21,10 +21,33 @@
 
 This chart is to deploy the kafka provider and package to OpenWhisk on a Kubernetes using Helm.
 
-## Preconditions
+## Config a CouchDB instance
 
-If you intend to use a Kafka instance that is external to Kubernetes as your broker, you can stop reading this section; there are no additional preconditions.
-However, if you want to use the Kakfa instance that is installed as part of the OpenWhisk deployment as your Kafka broker, you need to configure your OpenWhisk deployment so that the action containers use Kubernetes DNS. The easiest way to do this is to use the `KubernetesContainerFactory` as the [Invoker Container Factory](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/docs/configurationChoices.md#invoker-container-factory) in the Kubernetes cluster by adding below configuration in the `mycluster.yaml` when you deploy OpenWhisk with Helm:
+A CouchDB instance is required to save the event data. You can use the same CouchDB instance as part of the OpenWhisk deployment or you can use a different CouchDB instance. To use the same CouchDB instance as OpenWhisk, config `values.yaml` as:
+```
+db:
+  external: false
+  prefix: "cldt"
+```
+To use a different CouchDB instance, config the database parameters in `value.yaml` as:
+```
+db:
+  external: true
+  prefix: "cldt"
+  host: "0.0.0.0"
+  port: 5984
+  protocol: "http"
+  username: "admin"
+  password: "secret"
+```
+
+## Enable action containers to use Kubernetes DNS
+
+You need to enable action containers to use Kubernetes DNS under one of below conditions:
++ you use the same CouchDB instance as part of the OpenWhisk deployment to save event data;
++ you intend to use Kubernetes DNS name to locate a Kafka instance as the Kafka event provider.
+
+The easiest way to do this is to use the `KubernetesContainerFactory` as the [Invoker Container Factory](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/docs/configurationChoices.md#invoker-container-factory) in the Kubernetes cluster by adding below configuration in the `mycluster.yaml` when you deploy OpenWhisk with Helm:
 ```
 # Invoker configurations
 invoker:

--- a/helm/openwhisk-providers/charts/ow-kafka/templates/installPkgKafkaJob.yaml
+++ b/helm/openwhisk-providers/charts/ow-kafka/templates/installPkgKafkaJob.yaml
@@ -37,12 +37,30 @@ spec:
               configMapKeyRef:
                 name: whisk.config
                 key: whisk_api_host_nameAndPort
+          {{- if .Values.kafkaprovider.db.external }}
+          # Config database using the external cloudant instance
+          - name: "DB_PROTOCOL"
+            value: {{ .Values.kafkaprovider.db.protocol | quote }}
+          - name: "DB_HOST"
+            value: {{ .Values.kafkaprovider.db.host | quote }}
+          - name: "DB_USERNAME"
+            value: {{ .Values.kafkaprovider.db.username | quote }}
+          - name: "DB_PASSWORD"
+            value: {{ .Values.kafkaprovider.db.password | quote }}
+          - name: "DB_PORT"
+            value: {{ .Values.kafkaprovider.db.port | quote }}
+          {{- else }}
           # for the database used by kafka package
           - name: "DB_HOST"
             valueFrom:
               configMapKeyRef:
                 name: db.config
                 key: db_host
+          - name: "DB_PROTOCOL"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_protocol
           - name: "DB_PORT"
             valueFrom:
               configMapKeyRef:
@@ -58,8 +76,9 @@ spec:
               secretKeyRef:
                 name: db.auth
                 key: db_password
+          {{ end }}
           - name: "DB_PREFIX"
-            value: "{{- .Values.kafkaprovider.dbPrefix -}}"
+            value: "{{- .Values.kafkaprovider.db.prefix -}}"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/helm/openwhisk-providers/charts/ow-kafka/templates/pkgKafkaProvider.yaml
+++ b/helm/openwhisk-providers/charts/ow-kafka/templates/pkgKafkaProvider.yaml
@@ -27,6 +27,16 @@ spec:
         - name: kafkaprovider
           containerPort: {{ .Values.kafkaprovider.apiPort }}
         env:
+        {{- if .Values.kafkaprovider.db.external }}
+        # Config database using the external instance
+        - name: "DB_URL"
+          value: {{ .Values.kafkaprovider.db.protocol }}://{{ .Values.kafkaprovider.db.host }}:{{ .Values.kafkaprovider.db.port }}
+        - name: "DB_USER"
+          value: {{ .Values.kafkaprovider.db.username | quote }}
+        - name: "DB_PASS"
+          value: {{ .Values.kafkaprovider.db.password | quote }}
+        {{- else }}
+        # Config database using the same openwhisk cloudant instance
         - name: "DB_URL"
           valueFrom:
             configMapKeyRef:
@@ -42,8 +52,9 @@ spec:
             secretKeyRef:
               name: db.auth
               key: db_password
+        {{- end }}
         - name: "DB_PREFIX"
-          value: "{{- .Values.kafkaprovider.dbPrefix -}}"
+          value: "{{- .Values.kafkaprovider.db.prefix -}}"
         - name: "LOCAL_DEV"
           value: "true"
         - name: "ROUTER_HOST"

--- a/helm/openwhisk-providers/charts/ow-kafka/values.yaml
+++ b/helm/openwhisk-providers/charts/ow-kafka/values.yaml
@@ -10,7 +10,15 @@ kafkaprovider:
   imagePullPolicy: "IfNotPresent"
   restartPolicy: "Always"
   apiPort: 8080
-  dbPrefix: "kp"
+  db:
+    external: false
+    prefix: "kp"
+    # Add below values if you are using external couchdb instance
+    # host: "10.10.10.10"
+    # port: 5984
+    # protocol: "http"
+    # username: "admin"
+    # password: "secret"
 
 # Images used to run auxillary tasks/jobs
 utility:


### PR DESCRIPTION
This PR is to enable alarm and kafka provider to use external CouchDB instance to save event data.

Closes issue #283