### PR TITLE
Add travis test for providers

### DIFF
--- a/helm/openwhisk-providers/charts/ow-alarm/README.md
+++ b/helm/openwhisk-providers/charts/ow-alarm/README.md
@@ -65,7 +65,7 @@ invoker:
 
 You may install this chart with command like
 ```
-helm install ./helm/providers/charts/alarm --namespace=openwhisk --name owdev-alarm-provider
+helm install ./helm/openwhisk-providers/charts/ow-alarm --namespace=openwhisk --name owdev-alarm-provider
 ```
 
 You can use `helm status owdev-alarm-provider` to check the status. When you see pod is running and job is completed, you can check alarm package by `wsk package get /whisk.system/alarms -i --summary`

--- a/helm/openwhisk-providers/charts/ow-cloudant/README.md
+++ b/helm/openwhisk-providers/charts/ow-cloudant/README.md
@@ -67,7 +67,7 @@ invoker:
 
 You may install this chart with command like
 ```
-helm install ./helm/providers/charts/cloudant --namespace=openwhisk --name owdev-cloudant-provider
+helm install ./helm/openwhisk-providers/charts/ow-cloudant --namespace=openwhisk --name owdev-cloudant-provider
 ```
 
 You can use `helm status owdev-cloudant-provider` to check the status. When you see pod is running and job is completed, you can check cloudant package by `wsk package get /whisk.system/cloudant -i --summary`

--- a/tools/travis/build-helm.sh
+++ b/tools/travis/build-helm.sh
@@ -260,3 +260,57 @@ fi
 # fi
 
 echo "PASSED! Deployed openwhisk and invoked Hello action"
+
+####
+# now test the installation of kafka provider
+####
+helm install helm/openwhisk-providers/charts/ow-kafka --namespace=openwhisk --name=kafkap4travis
+
+jobHealthCheck "install-package-kafka"
+
+deploymentHealthCheck "kafkaprovider"
+
+# Verify messaging package is installed
+RESULT=$(wsk package list /whisk.system -i | grep messaging)
+if [ -z "$RESULT" ]; then
+  echo "FAILED! Could not list messaging package via CLI"
+  exit 1
+fi
+
+echo "PASSED! Deployed Kafka provider and package"
+
+####
+# now test the installation of Alarm provider
+####
+helm install helm/openwhisk-providers/charts/ow-alarm --namespace=openwhisk --name alarmp4travis
+
+jobHealthCheck "install-package-alarm"
+
+deploymentHealthCheck "alarmprovider"
+
+# Verify alarms package is installed
+RESULT=$(wsk package list /whisk.system -i | grep alarms)
+if [ -z "$RESULT" ]; then
+  echo "FAILED! Could not list alarms package via CLI"
+  exit 1
+fi
+
+echo "PASSED! Deployed Alarms provider and package"
+
+####
+# now test the installation of Cloudant provider
+####
+helm install helm/openwhisk-providers/charts/ow-cloudant --namespace=openwhisk --name cloudantp4travis
+
+jobHealthCheck "install-package-cloudant"
+
+deploymentHealthCheck "cloudantprovider"
+
+# Verify cloudant package is installed
+RESULT=$(wsk package list /whisk.system -i | grep cloudant)
+if [ -z "$RESULT" ]; then
+  echo "FAILED! Could not list cloudant package via CLI"
+  exit 1
+fi
+
+echo "PASSED! Deployed Cloudant provider and package"


### PR DESCRIPTION
Closes Issue #247 

Including:
- Add travis test for Kafka, Alarm and Cloudant providers
- Fix small errors of providers' README doc