### PR TITLE
Add optional Fluent Bit log enrichment agent

### DIFF
--- a/helm/openwhisk/templates/_invokerHelpers.tpl
+++ b/helm/openwhisk/templates/_invokerHelpers.tpl
@@ -25,6 +25,7 @@
   mountPath: "/var/run/docker.sock"
 - name: dockerrootdir
   mountPath: "/containers"
+  readOnly: true
 {{- end -}}
 
 {{- define "docker_pull_runtimes" -}}

--- a/helm/openwhisk/templates/logEnrich.yaml
+++ b/helm/openwhisk/templates/logEnrich.yaml
@@ -41,9 +41,9 @@ spec:
             value: "/var/log/containers/*/*-json.log"
           - name: "OW_FLUENTBIT_CONF_FILE"
 {{- if eq .Values.invoker.containerFactory.impl "kubernetes" }}
-            value: /fluent-bit/etc/ow-kcf-fileout.conf
-{{- else -}}
-            value: /fluent-bit/etc/ow-dcf-stdout.conf
+            value: "/fluent-bit/etc/ow-kcf-fileout.conf"
+{{- else }}
+            value: "/fluent-bit/etc/ow-dcf-fileout.conf"
 {{- end }}
         volumeMounts:
           - name: docker-containers

--- a/helm/openwhisk/templates/logEnrich.yaml
+++ b/helm/openwhisk/templates/logEnrich.yaml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+---
+{{- if .Values.invoker.containerFactory.externalLogEnrichment.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Values.invoker.containerFactory.externalLogEnrichment.name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    name: {{ .Values.invoker.containerFactory.externalLogEnrichment.name | quote }}
+spec:
+  selector:
+    matchLabels:
+      name: {{ .Values.invoker.containerFactory.externalLogEnrichment.name | quote }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.invoker.containerFactory.externalLogEnrichment.name | quote }}
+    spec:
+      restartPolicy: {{ .Values.invoker.restartPolicy }}
+
+      affinity:
+{{ include "affinity.invoker" . | indent 8 }}
+
+      volumes:
+{{ include "docker_volumes" . | indent 8 }}
+
+      containers:
+      - name: {{ .Values.invoker.containerFactory.externalLogEnrichment.name | quote }}
+        imagePullPolicy: {{ .Values.invoker.imagePullPolicy | quote }}
+        image: {{ .Values.invoker.containerFactory.externalLogEnrichment.image | quote }}
+        env:
+          - name: "OW_FLUENTBIT_INPUT_PATH"
+            value: "/containers/*/*-json.log"
+
+        volumeMounts:
+{{ include "docker_volume_mounts" . | indent 10 }}
+{{ end }}

--- a/helm/openwhisk/templates/logEnrich.yaml
+++ b/helm/openwhisk/templates/logEnrich.yaml
@@ -18,14 +18,19 @@ spec:
     metadata:
       labels:
         name: {{ .Values.invoker.containerFactory.externalLogEnrichment.name | quote }}
+    annotations:
+      fluentbit.io/exclude: "true"
     spec:
+      serviceAccountName: log-enrichment
       restartPolicy: {{ .Values.invoker.restartPolicy }}
 
       affinity:
 {{ include "affinity.invoker" . | indent 8 }}
 
       volumes:
-{{ include "docker_volumes" . | indent 8 }}
+        - name: docker-containers
+          hostPath:
+            path: "/var/lib/docker/containers"
 
       containers:
       - name: {{ .Values.invoker.containerFactory.externalLogEnrichment.name | quote }}
@@ -33,8 +38,15 @@ spec:
         image: {{ .Values.invoker.containerFactory.externalLogEnrichment.image | quote }}
         env:
           - name: "OW_FLUENTBIT_INPUT_PATH"
-            value: "/containers/*/*-json.log"
-
+            value: "/var/log/containers/*/*-json.log"
+          - name: "OW_FLUENTBIT_CONF_FILE"
+{{- if eq .Values.invoker.containerFactory.impl "kubernetes" }}
+            value: /fluent-bit/etc/ow-kcf-fileout.conf
+{{- else -}}
+            value: /fluent-bit/etc/ow-dcf-stdout.conf
+{{- end }}
         volumeMounts:
-{{ include "docker_volume_mounts" . | indent 10 }}
+          - name: docker-containers
+            mountPath: "/var/log/containers"
+            readOnly: true
 {{ end }}

--- a/helm/openwhisk/templates/rolebindings.yaml
+++ b/helm/openwhisk/templates/rolebindings.yaml
@@ -67,3 +67,36 @@ roleRef:
   name: {{ .Values.invoker.name | quote }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+
+{{- if .Values.invoker.containerFactory.externalLogEnrichment.enabled }}
+# Give the fluent-bit DaemonSet the ability to view pod/namespaces to
+# extract Pod metadata (labels/annotations) for the Kubernetes Filter plugin
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: log-enrichment
+  namespace: {{ .Release.Namespace | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: log-enrichment-read
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "pods"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: log-enrichment-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: log-enrichment-read
+subjects:
+- kind: ServiceAccount
+  name: log-enrichment
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -169,6 +169,10 @@ invoker:
   jvmOptions: ""
   containerFactory:
     useRunc: false
+    externalLogEnrichment:
+      name: "log-enrich-agent"
+      image: "dgrove/ow-fluent-bit:latest"
+      enabled: true
     impl: "docker"
     kubernetes:
       replicaCount: 1


### PR DESCRIPTION
Companion to OW core PR https://github.com/apache/incubator-openwhisk/pull/3974.

Adds an optional DaemonSet of Fuent Bit log processing agents to enrich the user container logs with activationIds. 




