### PR TITLE
travisCI improvements

### DIFF
--- a/helm/openwhisk/templates/installCatalogJob.yaml
+++ b/helm/openwhisk/templates/installCatalogJob.yaml
@@ -19,7 +19,7 @@ spec:
           name: install-catalog
       initContainers:
       # Wait for a controller to be up so we can perfom our CRUD actions with the CLI
-{{ include "readiness.waitForController" . | indent 6 }}
+{{ include "readiness.waitForHealthyInvoker" . | indent 6 }}
       containers:
       - name: catalog
         image: {{ .Values.utility.scriptRunnerImage | quote }}

--- a/helm/openwhisk/templates/installRouteMgmtJob.yaml
+++ b/helm/openwhisk/templates/installRouteMgmtJob.yaml
@@ -19,7 +19,7 @@ spec:
           name: install-routemgmt
       initContainers:
       # Wait for a controller to be up so we can perfom our CRUD actions with the CLI
-{{ include "readiness.waitForController" . | indent 6 }}
+{{ include "readiness.waitForHealthyInvoker" . | indent 6 }}
       containers:
       - name: routemgmt
         image: {{ .Values.utility.scriptRunnerImage | quote }}

--- a/tools/travis/build-helm.sh
+++ b/tools/travis/build-helm.sh
@@ -282,7 +282,7 @@ echo "PASSED! Deployed Kafka provider and package"
 ####
 # now test the installation of Alarm provider
 ####
-helm install helm/openwhisk-providers/charts/ow-alarm --namespace=openwhisk --name alarmp4travis
+helm install helm/openwhisk-providers/charts/ow-alarm --namespace=openwhisk --name alarmp4travis --set alarmprovider.persistence.storageClass=standard
 
 jobHealthCheck "install-package-alarm"
 
@@ -300,7 +300,7 @@ echo "PASSED! Deployed Alarms provider and package"
 ####
 # now test the installation of Cloudant provider
 ####
-helm install helm/openwhisk-providers/charts/ow-cloudant --namespace=openwhisk --name cloudantp4travis
+helm install helm/openwhisk-providers/charts/ow-cloudant --namespace=openwhisk --name cloudantp4travis --set cloudantprovider.persistence.storageClass=standard
 
 jobHealthCheck "install-package-cloudant"
 


### PR DESCRIPTION
1. On minikube the default storageClass is called `standard`, so we need to provide this value for those charts that require PVs to deploy successfully.
    
2. Add a readiness check for a healthy invoker and gate the catalog/routemgmt install jobs on that test.  This should cause them to wait long enough to avoid whatever race condition is causing them to often error out with 500 error code from couchdb.
