### PR TITLE
Add an option include OpenWhisk system tests in TravisCI testing  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
-sudo: required
+
+# See https://github.com/travis-ci/travis-ci/issues/10212
+group: edge
+
 dist: xenial
+sudo: required
+jdk: openjdk8
 
 env:
   global:
   - secure: d7CuMXbhT83W2x78qiLwgogX1+3aPicd1PlTwwNNDN6QSkImbxareyKThnsqlHIiNj3o5l5DBuiYjy7wrF/xD1g8BQMmTwm99DRx5q3CI3Im3VCi/ZK8SaNjuOy24d7cf5k2tB/87Gk7zmKsMDYm+fpCl+GpgUmIEeIwthiAxuXSDWZ8eQPIptmxj56DeFRNouvXG+dEUtBfWiwN27UPxNKExCixFnegmdtffLbz6hhst7BHr5Ry9acbycre98PCwWZcu9lxFs+SJ1kvnzX2iue4otmDkF1WkJjxaOFPJVs/D3YItg+neLCSxjwBskPed+Fct8bOjcM/uVROJPNIq5icBmaPX2isH0lvtxOeVw/dmioWYXYPN9ygBOe4eO/vtPllN0bcAUo5xl9jXev8ciAozYrYpHVh9Fplfd81rcYTeYzALmRJBdoiWoc3KQGzwGc9sB1ffmy+KWgG9T0zbnS4fALSR4PSzyNlKSLXw9vuvdNP0OBYtO+6yTJXavIxqmDoj64Lb93n+uGPatnaIGPTKEEBMJTSjsgYVEfxzzZuxUT9Ldkf2lzqvN2PCllGoMqxkgsdb8i4v4QgRaMWBDbKa5Va4k0O4dnhRmtdbJavOSKN6fECJbyfoJlV1VvJGxk5znVLRznBmUPBKbNccyPZJULugKD3QIh4q8Q5jBU=
   - secure: CJtnU94HTDqd4A6uvhFl8IpnmU+wTdlzb8bPBFUl/lI/VKXiRrYpgJdKUro5xEoxFKuqMprLhbyf66niyWLTIeogjUAEu/h/o2dBVeGgSGKoqC0hQgqvnxKFeGlzFJ0XuEs3vbStJGRnQszGsfnnDrscJtR0x9X+1w4aBKI7iPyyuFtVkDD1UsmBbSi+M8FTeq7G7A0reMDaey7uog3CFCpIMl4geshcohQEcKEGbnXQZoLPFpb7cBOE83VXBJ7Y7Dgf/U4keiLovvnuJThGKZm/SVV2KlELmBmtmbx3rMT6Vb5k9ChSdRWapromNnnzmJBIQ5Scc2mwV3A93/SMha1F3IlYpDKs5djfTw8jZfVnuiou7HhTaRjHkmmcwP12/k30gLe2kw0Vezg1TCY4zgtOpcmCxc8RHEy0ceA74rKvRi8LbexTCwX+iAMQFn/pSrh/OqAq/50JbLyczcoO1zXWS38txUQNLW8i+XllhCg9pjkjyfBeGjOOcWiVIz9rWJd2XufjSXDcj6xoZHtkh1XDt1CnVkpsYKtyyZucQnhUM9ebmaWqbSW2+bpqC/2hI+G+kOyyCesGdB1q+VmN1augMMs6RgWjk4yw5dyLAshATSoUlE8KH2cDcJL19r4ECaQ99PSLwxoB89yfPoJiNc42vwxRdsLmB1BMNyPa81Y=
   matrix:
-    - TRAVIS_KUBE_VERSION=1.10 OW_CONTAINER_FACTORY=docker
-    - TRAVIS_KUBE_VERSION=1.10 OW_CONTAINER_FACTORY=kubernetes
-    - TRAVIS_KUBE_VERSION=1.11 OW_CONTAINER_FACTORY=docker
+    - TRAVIS_KUBE_VERSION=1.10 OW_RUN_SYSTEM_TESTS=no OW_CONTAINER_FACTORY=docker
+    - TRAVIS_KUBE_VERSION=1.10 OW_RUN_SYSTEM_TESTS=no OW_CONTAINER_FACTORY=kubernetes
+    - TRAVIS_KUBE_VERSION=1.11 OW_RUN_SYSTEM_TESTS=no OW_CONTAINER_FACTORY=docker
 
 services:
   - docker


### PR DESCRIPTION
Unfortunately this additional level of testing is still disabled by default because although it passes fairly reliably when run on a development machine, it fails almost 100% of the time in the TravisCI environment.
    
Also include a retry loop around the `wsk action list` smoketest in buildHelm.sh and the `wsk package list` checks because there is annoyingly often a delay between the entity being created successfully and it showing up in `list` operations.

