### PR TITLE
Making the instructions for replacing port for docker-for-mac clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ instructions [here](https://github.com/apache/incubator-openwhisk-cli)
 to get it). Replace `whisk.ingress.apiHostName` and `whisk.ingress.apiHostPort`
 with the actual values from your mycluster.yaml.
 ```shell
-wsk property set --apihost whisk.ingress.apiHostName:whisk.ingress.apiHostPort
+wsk property set --apihost <whisk.ingress.apiHostName>:<whisk.ingress.apiHostPort>
 wsk property set --auth 23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
 ```
 ### Configuring the CLI for Kubernetes on Docker for Mac
@@ -248,11 +248,12 @@ wsk property set --auth 23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK
 The `docker0` network interface does not exist in the Docker for Mac
 host environment. Instead, exposed NodePorts are forwarded from localhost
 to the appropriate containers.  This means that you will use `localhost`
-instead of `whisk.ingress.apiHostName` as your apihost when configuring
-the `wsk` cli.
+instead of `whisk.ingress.apiHostName` when configuring
+the `wsk` cli and replace `whisk.ingress.apiHostPort`
+with the actual values from your mycluster.yaml.
 
 ```shell
-wsk property set --apihost localhost:whisk.ingress.apiHostPort
+wsk property set --apihost localhost:<whisk.ingress.apiHostPort>
 wsk property set --auth 23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
 ```
 


### PR DESCRIPTION
just a readme change to be explicit about replacing the port value and not replacing the host name for docker-for-mac