### PR TITLE
Fix YAML parse error in redis-pod.yaml

### DIFF
--- a/helm/openwhisk/templates/redis-pod.yaml
+++ b/helm/openwhisk/templates/redis-pod.yaml
@@ -54,7 +54,7 @@ spec:
           imagePullPolicy: {{ .Values.redis.imagePullPolicy | quote }}
           image: {{ .Values.redis.image | quote }}
 {{- if .Values.redis.persistence.enabled }}
-         volumeMounts:
+          volumeMounts:
           - mountPath: /data
             name: redis-data
             readOnly: false


### PR DESCRIPTION
A space was removed in commit #340. That causes a parse error when persistence is enabled.