### PR TITLE
Update for upstream changes in loadbalancer/invoker memory config

### DIFF
--- a/docs/configurationChoices.md
+++ b/docs/configurationChoices.md
@@ -200,7 +200,7 @@ to your `mycluster.yaml`
 
 For scalability, you will probably want to use `replicaCount` to
 deploy more than one Invoker when using the KubernetesContainerFactory.
-You will also need to override the value of `whisk.loadbalancer.invokerUserMemory`
+You will also need to override the value of `whisk.containerPool.userMemory`
 to a significantly larger value when using the KubernetesContainerFactory
 to better match the overall memory available on invoker worker nodes divided by
 the number of Invokers you are creating.

--- a/helm/openwhisk/templates/controller-pod.yaml
+++ b/helm/openwhisk/templates/controller-pod.yaml
@@ -83,8 +83,11 @@ spec:
         - name: "RUNTIMES_MANIFEST"
           value: {{ template "openwhisk.runtimes_manifest" . }}
 
-        - name: "CONFIG_whisk_loadbalancer_invokerUserMemory"
-          value: {{ .Values.whisk.loadbalancer.invokerUserMemory | quote }}
+        - name: "CONFIG_whisk_loadbalancer_blackboxFraction"
+          value: {{ .Values.whisk.loadbalancer.blackboxFraction | quote }}
+
+        - name: "CONFIG_whisk_loadbalancer_timeoutFactor"
+          value: {{ .Values.whisk.loadbalancer.timeoutFactor | quote }}
 
         # Kafka properties
         - name: "KAFKA_HOSTS"

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -93,8 +93,8 @@ spec:
           - name: "DOCKER_REGISTRY"
             value: {{ .Values.docker.registry.name | quote }}
 
-          - name: "CONFIG_whisk_loadbalancer_invokerUserMemory"
-            value: {{ .Values.whisk.loadbalancer.invokerUserMemory | quote }}
+          - name: "CONFIG_whisk_containerPool_userMemory"
+            value: {{ .Values.whisk.containerPool.userMemory | quote }}
 
           # DNS Server passed to action containers
 {{- if not (eq .Values.invoker.kubeDNS "nil") }}

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -37,7 +37,10 @@ whisk:
   systemNameSpace: "/whisk.system"
   runtimes: "runtimes.json"
   loadbalancer:
-    invokerUserMemory: "2048m"
+    blackboxFraction: "10%"
+    timeoutFactor: 2
+  containerPool:
+    userMemory: "2048m"
 
 # Properties of the Kubernetes cluster on which OpenWhisk is being deployed
 k8s:


### PR DESCRIPTION
The name of invokerUserMemory was changed upstream in 5b3e0b6a3 and
deploy-kube was never updated to catch up with the change.