### PR TITLE
Move smoketest into chart so it can be used for `helm test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Your OpenWhisk installation should now be usable.  You can test it by following
 [these instructions](https://github.com/apache/incubator-openwhisk/blob/master/docs/actions.md)
 to define and invoke a sample OpenWhisk action in your favorite programming language.
 
+You can also issue the command `helm test owdev` to run the basic verification
+test suite included in the OpenWhisk Helm chart.
+
 Note: if you installed self-signed certificates, which is the default
 for the OpenWhisk Helm chart, you will need to use `wsk -i` to
 suppress certificate checking.  This works around `cannot validate

--- a/helm/openwhisk/templates/tests/smoketest-cm.yaml
+++ b/helm/openwhisk/templates/tests/smoketest-cm.yaml
@@ -1,0 +1,10 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openwhisk-tests-smoketest-cm
+  namespace: {{ .Release.Namespace | quote }}
+data:
+{{ (.Files.Glob "configMapFiles/tests/smoketest/myTask.sh").AsConfig | indent 2 }}

--- a/helm/openwhisk/templates/tests/smoketest-pod.yaml
+++ b/helm/openwhisk/templates/tests/smoketest-pod.yaml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: openwhisk-tests-smoketest
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    name: openwhisk-tests-smoketest
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  restartPolicy: Never
+  volumes:
+  - name: task-dir
+    configMap:
+      name: openwhisk-tests-smoketest-cm
+  containers:
+  - name: smoketest
+    image: {{ .Values.utility.scriptRunnerImage | quote }}
+    imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
+    volumeMounts:
+    - name: task-dir
+      mountPath: "/task/myTask.sh"
+      subPath: "myTask.sh"
+    env:
+      - name: "WSK_AUTH"
+        valueFrom:
+          secretKeyRef:
+            name: whisk.auth
+            key: guest
+      - name: "WSK_API_HOST_URL"
+        valueFrom:
+          configMapKeyRef:
+            name: whisk.config
+            key: whisk_api_host_url

--- a/tools/travis/build-helm.sh
+++ b/tools/travis/build-helm.sh
@@ -248,67 +248,25 @@ verifyHealthyInvoker
 jobHealthCheck "install-catalog"
 jobHealthCheck "install-routemgmt"
 
+
+###
 # Configure wsk CLI
+###
 WSK_AUTH=$(kubectl -n openwhisk get secret whisk.auth -o jsonpath='{.data.guest}' | base64 --decode)
 wsk property set --auth $WSK_AUTH --apihost $WSK_HOST:$WSK_PORT
 
-#################
-# Sniff test: create and invoke a simple Hello world action
-#################
 
-# create wsk action
-cat > /tmp/hello.js << EOL
-function main() {
-  return {body: 'Hello world'}
-}
-EOL
-wsk -i action create hello /tmp/hello.js --web true
-
-# first list actions and expect to see hello
-# Try several times to accommodate eventual consistency of CouchDB
-ACTION_LIST_PASSED=false
-ACTION_LIST_ATTEMPTS=0
-until $ACTION_LIST_PASSED; do
-  RESULT=$(wsk -i action list | grep hello)
-  if [ -z "$RESULT" ]; then
-    let ACTION_LIST_ATTEMPTS=ACTION_LIST_ATTEMPTS+1
-    if [ $ACTION_LIST_ATTEMPTS -gt 5 ]; then
-      echo "FAILED! Could not list hello action via CLI"
-      exit 1
-    fi
-    echo "wsk action list did not include hello; sleep 5 seconds and try again"
-    sleep 5
-  else
-      echo "success: wsk action list included hello"
-      ACTION_LIST_PASSED=true
-  fi
-done
-
-# next invoke the new hello world action via the CLI
-RESULT=$(wsk -i action invoke --blocking hello | grep "\"status\": \"success\"")
-if [ -z "$RESULT" ]; then
-  echo "FAILED! Could not invoke hello action via CLI"
-  exit 1
+###
+# Now run the tests provided in the Chart to sanity check the deployment
+###
+if helm test ow4travis; then
+    echo "PASSED! Deployment verification tests passed."
+else
+    echo "FAILED: Deployment verification tests failed."
+    kubectl logs -n openwhisk openwhisk-tests-smoketest
+    exit 1
 fi
 
-# now run it as a web action
-HELLO_URL=$(wsk -i action get hello --url | grep "https://")
-RESULT=$(wget --no-check-certificate -qO- $HELLO_URL | grep 'Hello world')
-if [ -z "$RESULT" ]; then
-  echo "FAILED! Could not invoke hello as a web action"
-  exit 1
-fi
-
-# now define it as an api and invoke it that way
-wsk -i api create /demo /hello get hello
-API_URL=$(wsk -i api list | grep hello | awk '{print $4}')
-RESULT=$(wget --no-check-certificate -qO- "$API_URL" | grep 'Hello world')
-if [ -z "$RESULT" ]; then
-  echo "FAILED! Could not invoke hello via apigateway"
-  exit 1
-fi
-
-echo "PASSED! Created Hello action and invoked via cli, web and apigateway"
 
 ###
 # Now install all the provider helm charts.


### PR DESCRIPTION
Pull the logic for the simple hello action smoketest into the
Helm chart for OpenWhisk so it can be used to verify that the
Chart deployed correctly.