### PR TITLE
Also tag with githash when tagging with latest

### DIFF
--- a/tools/travis/publish.sh
+++ b/tools/travis/publish.sh
@@ -13,3 +13,10 @@ dockerhub_image="${dockerhub_image_prefix}/${dockerhub_image_name}:${dockerhub_i
 docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
 docker build ${dir_to_build} --tag ${dockerhub_image}
 docker push ${dockerhub_image}
+
+if [ ${dockerhub_image_tag} == "latest" ]; then
+    short_commit=`git rev-parse --short HEAD`
+    dockerhub_image_alias="${dockerhub_image_prefix}/${dockerhub_image_name}:${short_commit}"
+    docker tag ${dockerhub_image} ${dockerhub_image_alias}
+    docker push ${dockerhub_image_alias}
+fi


### PR DESCRIPTION
If tagging an image with latest, also tag it with the short
githash of current head so we can have a stable tag on dockerhub.

Fixes #359