### PR TITLE
Switch to pinned docker images and git clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,11 +277,11 @@ If you are using Kubernetes in Docker, it is
 straightforward to deploy local images by adding a stanza to your
 mycluster.yaml. For example, to use a locally built controller image,
 just add the stanza below to your `mycluster.yaml` to override the default
-behavior of pulling `openwhisk/controller:latest` from Docker Hub.
+behavior of pulling a stable `openwhisk/controller` image from Docker Hub.
 ```yaml
 controller:
-  image: "whisk/controller"
-  imagePullPolicy: "IfNotPresent"
+  imageName: "whisk/controller"
+  imageTag: "latest"
 ```
 
 ### Selectively redeploying using a locally built docker image
@@ -299,8 +299,8 @@ docker tag whisk/controller whisk/controller:v2
 Then, edit your `mycluster.yaml` to contain:
 ```yaml
 controller:
-  image: "whisk/controller:v2"
-  imagePullPolicy: "IfNotPresent"
+  imageName: "whisk/controller"
+  imageTag: "v2"
 ```
 Redeploy with Helm by executing this commaned in your
 openwhisk-deploy-kube directory:

--- a/docs/k8s-docker-for-mac.md
+++ b/docs/k8s-docker-for-mac.md
@@ -72,11 +72,11 @@ visible/accessible via the usual Docker commands. Furthermore, it is
 straightforward to deploy local images by adding a stanza to your
 mycluster.yaml. For example, to use a locally built controller image,
 just add the stanza below to your `mycluster.yaml` to override the default
-behavior of pulling `openwhisk/controller:latest` from Docker Hub.
+behavior of pulling a stable `openwhisk/controller` image from Docker Hub.
 ```yaml
 controller:
-  image: "whisk/controller"
-  imagePullPolicy: "IfNotPresent"
+  imageName: "whisk/controller"
+  imageTag: "latest"
 ```
 
 ## Limitations

--- a/helm/openwhisk/configMapFiles/initCouchDB/initdb.sh
+++ b/helm/openwhisk/configMapFiles/initCouchDB/initdb.sh
@@ -3,6 +3,9 @@
 
 # Clone OpenWhisk to get the ansible playbooks needed to initialize CouchDB
 git clone https://github.com/apache/incubator-openwhisk /openwhisk
+pushd /openwhisk
+    git checkout $OW_GIT_TAG_OPENWHISK
+popd
 
 # Copy the secrets whisk.auth.guest and whisk.auth.system into the cloned tree
 # overwriting the default values we cloned from git

--- a/helm/openwhisk/configMapFiles/installPackages/myTask.sh
+++ b/helm/openwhisk/configMapFiles/installPackages/myTask.sh
@@ -11,6 +11,9 @@ export PROVIDER_DB_URL=$PROVIDER_DB_PROTOCOL://$PROVIDER_DB_USERNAME:$PROVIDER_D
 
 # Clone openwhisk repo to get installRouteMgmt.sh and core/routemgmt
 git clone https://github.com/apache/incubator-openwhisk openwhisk
+pushd openwhisk
+    git checkout $OW_GIT_TAG_OPENWHISK
+popd
 
 # Setup env for installRouteMgmt.sh
 if [ "$WHISK_API_GATEWAY_USER" ]; then
@@ -39,6 +42,9 @@ popd
 # Install the OpenWhisk Catalog
 #####
 git clone https://github.com/apache/incubator-openwhisk-catalog openwhisk-catalog
+pushd openwhisk-catalog
+    git checkout $OW_GIT_TAG_OPENWHISK_CATALOG
+popd
 
 pushd openwhisk-catalog/packages
     ./installCatalog.sh $WHISK_AUTH $WHISK_API_HOST /usr/local/bin/wsk
@@ -62,6 +68,7 @@ if [ "$OW_INSTALL_ALARM_PROVIDER" == "yes" ]; then
     git clone https://github.com/apache/incubator-openwhisk-package-alarms.git
 
     pushd /incubator-openwhisk-package-alarms
+        git checkout $OW_GIT_TAG_OPENWHISK_PACKAGE_ALARMS
         ./installCatalog.sh $WHISK_AUTH $WHISK_API_HOST $PROVIDER_DB_URL $ALARM_DB_PREFIX $WHISK_API_HOST
     popd
 fi
@@ -76,6 +83,7 @@ if [ "$OW_INSTALL_CLOUDANT_PROVIDER" == "yes" ]; then
     git clone https://github.com/apache/incubator-openwhisk-package-cloudant.git
 
     pushd /incubator-openwhisk-package-cloudant
+        git checkout $OW_GIT_TAG_OPENWHISK_PACKAGE_CLOUDANT
         ./installCatalog.sh $WHISK_AUTH $WHISK_API_HOST $PROVIDER_DB_URL $CLOUDANT_DB_PREFIX $WHISK_API_HOST
     popd
 fi
@@ -90,6 +98,7 @@ if [ "$OW_INSTALL_KAFKA_PROVIDER" == "yes" ]; then
     git clone https://github.com/apache/incubator-openwhisk-package-kafka.git
 
     pushd /incubator-openwhisk-package-kafka
+        git checkout $OW_GIT_TAG_OPENWHISK_PACKAGE_KAFKA
         ./installKafka.sh $WHISK_AUTH $WHISK_API_HOST $PROVIDER_DB_URL $KAFKA_DB_PREFIX $WHISK_API_HOST
         ./installCatalog.sh $WHISK_AUTH $WHISK_API_HOST $PROVIDER_DB_URL $KAFKA_DB_PREFIX $WHISK_API_HOST
     popd

--- a/helm/openwhisk/runtimes-minimal-travis.json
+++ b/helm/openwhisk/runtimes-minimal-travis.json
@@ -7,7 +7,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "nodejs6action",
-                    "tag": "latest"
+                    "tag": "d967ebe"
                 },
                 "deprecated": false,
                 "stemCells": [{
@@ -22,7 +22,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "python3action",
-                    "tag": "latest"
+                    "tag": "de60587"
                 },
                 "deprecated": false
             }
@@ -32,7 +32,7 @@
         {
             "prefix": "openwhisk",
             "name": "dockerskeleton",
-            "tag": "latest"
+            "tag": "8b2e205"
         }
     ]
 }

--- a/helm/openwhisk/runtimes.json
+++ b/helm/openwhisk/runtimes.json
@@ -7,7 +7,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "nodejs6action",
-                    "tag": "latest"
+                    "tag": "d967ebe"
                 },
                 "deprecated": false,
                 "attached": {
@@ -27,7 +27,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-nodejs-v8",
-                    "tag": "latest"
+                    "tag": "d967ebe"
                 },
                 "deprecated": false,
                 "attached": {
@@ -42,7 +42,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "python2action",
-                    "tag": "latest"
+                    "tag": "de60587"
                 },
                 "deprecated": false,
                 "attached": {
@@ -56,7 +56,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "python2action",
-                    "tag": "latest"
+                    "tag": "de60587"
                 },
                 "deprecated": false,
                 "attached": {
@@ -69,7 +69,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "python3action",
-                    "tag": "latest"
+                    "tag": "de60587"
                 },
                 "deprecated": false,
                 "attached": {
@@ -84,7 +84,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-swift-v3.1.1",
-                    "tag": "latest"
+                    "tag": "1.0.3"
                 },
                 "deprecated": false,
                 "attached": {
@@ -98,7 +98,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-swift-v4.1",
-                    "tag": "latest"
+                    "tag": "1.0.8"
                 },
                 "deprecated": false,
                 "attached": {
@@ -114,7 +114,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "java8action",
-                    "tag": "latest"
+                    "tag": "1.1.2"
                 },
                 "deprecated": false,
                 "attached": {
@@ -132,7 +132,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-php-v7.1",
-                    "tag": "latest"
+                    "tag": "ab65b67"
                 },
                 "attached": {
                     "attachmentName": "codefile",
@@ -146,7 +146,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-php-v7.2",
-                    "tag": "latest"
+                    "tag": "ab65b67"
                 },
                 "attached": {
                     "attachmentName": "codefile",
@@ -166,7 +166,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-ruby-v2.5",
-                    "tag": "latest"
+                    "tag": "78e1406"
                 }
             }
         ],
@@ -182,7 +182,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "actionloop-golang-v1.11",
-                    "tag": "latest"
+                    "tag": "e7fb79c"
                 }
             }
         ]
@@ -191,7 +191,7 @@
         {
             "prefix": "openwhisk",
             "name": "dockerskeleton",
-            "tag": "latest"
+            "tag": "8b2e205"
         }
     ]
 }

--- a/helm/openwhisk/templates/_invoker-helpers.tpl
+++ b/helm/openwhisk/templates/_invoker-helpers.tpl
@@ -33,8 +33,8 @@
 
 {{- define "openwhisk.docker_pull_runtimes" -}}
 - name: docker-pull-runtimes
-  imagePullPolicy: {{ .Values.invoker.imagePullPolicy | quote }}
-  image: {{ .Values.invoker.pullRuntimesImage | quote }}
+  imagePullPolicy: {{ .Values.utility.ansibleRunner.imagePullPolicy | quote }}
+  image: "{{- .Values.utility.ansibleRunner.imageName -}}:{{- .Values.utility.ansibleRunner.imageTag -}}"
   volumeMounts:
   - name: dockersock
     mountPath: "/var/run/docker.sock"

--- a/helm/openwhisk/templates/apigateway-pod.yaml
+++ b/helm/openwhisk/templates/apigateway-pod.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: apigateway
           imagePullPolicy: {{ .Values.apigw.imagePullPolicy | quote }}
-          image: {{ .Values.apigw.image | quote }}
+          image: "{{- .Values.apigw.imageName -}}:{{- .Values.apigw.imageTag -}}"
           ports:
           - name: mgmt
             containerPort: {{ .Values.apigw.mgmtPort }}

--- a/helm/openwhisk/templates/controller-pod.yaml
+++ b/helm/openwhisk/templates/controller-pod.yaml
@@ -38,7 +38,7 @@ spec:
       containers:
       - name: {{ .Values.controller.name | quote }}
         imagePullPolicy: {{ .Values.controller.imagePullPolicy | quote }}
-        image: {{ .Values.controller.image | quote }}
+        image: "{{- .Values.controller.imageName -}}:{{- .Values.controller.imageTag -}}"
         command: ["/bin/bash", "-c", "/init.sh `hostname | cut -d'-' -f2`"]
         ports:
         - name: controller

--- a/helm/openwhisk/templates/couchdb-init-job.yaml
+++ b/helm/openwhisk/templates/couchdb-init-job.yaml
@@ -28,7 +28,7 @@ spec:
           secretName: whisk.auth
       containers:
       - name: init-couchdb
-        image: {{ .Values.utility.ansibleRunnerImage | quote }}
+        image: "{{- .Values.utility.ansibleRunner.imageName -}}:{{- .Values.utility.ansibleRunner.imageTag -}}"
         imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
         command: ["/bin/bash", "-c", "set -e; . /task/initdb.sh"]
         volumeMounts:
@@ -70,4 +70,8 @@ spec:
               key: db_password
         - name: "NODENAME"
           value: "couchdb0"
+
+        # tag to use for git clone to get ansible files to initialize couchdb
+        - name: "OW_GIT_TAG_OPENWHISK"
+          value: {{ .Values.whisk.versions.openwhisk.gitTag | quote }}
 {{ end }}

--- a/helm/openwhisk/templates/couchdb-pod.yaml
+++ b/helm/openwhisk/templates/couchdb-pod.yaml
@@ -30,8 +30,8 @@ spec:
 
       containers:
       - name: {{ .Values.db.name | quote }}
+        image: "{{- .Values.db.imageName -}}:{{- .Values.db.imageTag -}}"
         imagePullPolicy: {{ .Values.db.imagePullPolicy | quote }}
-        image: {{ .Values.db.image | quote }}
         ports:
         - name: couchdb
           containerPort: {{ .Values.db.port }}

--- a/helm/openwhisk/templates/install-packages-job.yaml
+++ b/helm/openwhisk/templates/install-packages-job.yaml
@@ -24,8 +24,8 @@ spec:
 {{ include "openwhisk.readiness.waitForHealthyInvoker" . | indent 6 }}
       containers:
       - name: install-packages
-        image: {{ .Values.utility.scriptRunnerImage | quote }}
-        imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
+        image: "{{- .Values.utility.scriptRunner.imageName -}}:{{- .Values.utility.scriptRunner.imageTag -}}"
+        imagePullPolicy: {{ .Values.utility.scriptRunner.imagePullPolicy | quote }}
         volumeMounts:
         - name: task-dir
           mountPath: "/task/myTask.sh"
@@ -108,3 +108,15 @@ spec:
             value: {{ if .Values.providers.cloudant.enabled }} "yes" {{ else }} "no" {{ end }}
           - name: "OW_INSTALL_KAFKA_PROVIDER"
             value: {{ if .Values.providers.kafka.enabled }} "yes" {{ else }} "no" {{ end }}
+
+          # tags to use for git clone operations
+          - name: "OW_GIT_TAG_OPENWHISK"
+            value: {{ .Values.whisk.versions.openwhisk.gitTag | quote }}
+          - name: "OW_GIT_TAG_OPENWHISK_CATALOG"
+            value: {{ .Values.whisk.versions.openwhiskCatalog.gitTag | quote }}
+          - name: "OW_GIT_TAG_OPENWHISK_PACKAGE_ALARMS"
+            value: {{ .Values.whisk.versions.openwhiskPackageAlarms.gitTag | quote }}
+          - name: "OW_GIT_TAG_OPENWHISK_PACKAGE_CLOUDANT"
+            value: {{ .Values.whisk.versions.openwhiskPackageCloudant.gitTag | quote }}
+          - name: "OW_GIT_TAG_OPENWHISK_PACKAGE_KAFKA"
+            value: {{ .Values.whisk.versions.openwhiskPackageKafka.gitTag | quote }}

--- a/helm/openwhisk/templates/invoker-agent-pod.yaml
+++ b/helm/openwhisk/templates/invoker-agent-pod.yaml
@@ -39,8 +39,8 @@ spec:
 
       containers:
       - name: {{ .Values.invoker.containerFactory.kubernetes.agent.name | quote }}
+        image: "{{- .Values.invoker.containerFactory.kubernetes.agent.imageName -}}:{{- .Values.invoker.containerFactory.kubernetes.agent.imageTag -}}"
         imagePullPolicy: {{ .Values.invoker.imagePullPolicy | quote }}
-        image: {{ .Values.invoker.containerFactory.kubernetes.agent.image }}
         securityContext:
           privileged: true
         ports:

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -56,8 +56,8 @@ spec:
 
       containers:
       - name: {{ .Values.invoker.name | quote }}
+        image: "{{- .Values.invoker.imageName -}}:{{- .Values.invoker.imageTag -}}"
         imagePullPolicy: {{ .Values.invoker.imagePullPolicy | quote }}
-        image: {{ .Values.invoker.image | quote }}
         command: [ "/bin/bash", "-c", "/init.sh --uniqueName $INVOKER_NAME" ]
         env:
           - name: "PORT"
@@ -83,14 +83,6 @@ spec:
             value: {{ .Values.invoker.containerNetwork | quote }}
           - name: "CONFIG_whisk_docker_containerFactory_useRunc"
             value: {{ .Values.invoker.containerFactory.useRunc | quote }}
-
-          # Properties for invoker image
-          - name: "DOCKER_IMAGE_PREFIX"
-            value: {{ .Values.docker.image.prefix | quote }}
-          - name: "DOCKER_IMAGE_TAG"
-            value: {{ .Values.docker.image.tag | quote }}
-          - name: "DOCKER_REGISTRY"
-            value: {{ .Values.docker.registry.name | quote }}
 
           - name: "CONFIG_whisk_containerPool_userMemory"
             value: {{ .Values.whisk.containerPool.userMemory | quote }}

--- a/helm/openwhisk/templates/kafka-pod.yaml
+++ b/helm/openwhisk/templates/kafka-pod.yaml
@@ -42,7 +42,7 @@ spec:
 
       containers:
       - name: {{ .Values.kafka.name | quote }}
-        image: {{ .Values.kafka.image | quote }}
+        image: "{{- .Values.kafka.imageName -}}:{{- .Values.kafka.imageTag -}}"
         imagePullPolicy: {{ .Values.kafka.imagePullPolicy | quote }}
 {{- if .Values.k8s.persistence.enabled }}
         volumeMounts:

--- a/helm/openwhisk/templates/nginx-pod.yaml
+++ b/helm/openwhisk/templates/nginx-pod.yaml
@@ -39,8 +39,8 @@ spec:
 
       containers:
       - name: {{ .Values.nginx.name | quote }}
+        image: "{{- .Values.nginx.imageName -}}:{{- .Values.nginx.imageTag -}}"
         imagePullPolicy: {{ .Values.nginx.imagePullPolicy | quote }}
-        image: {{ .Values.nginx.image | quote }}
         ports:
         - name: http
           containerPort: {{ .Values.nginx.httpPort }}

--- a/helm/openwhisk/templates/ow-whisk-cm.yaml
+++ b/helm/openwhisk/templates/ow-whisk-cm.yaml
@@ -17,9 +17,9 @@ metadata:
   labels:
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
 data:
-  whisk_info_date: {{ dateInZone "2006-01-02-03:04:05Z" (now) "UTC"| quote }}
-  whisk_info_buildNo: {{ .Values.whisk.versions.tag | quote }}
-  whisk_cli_version_tag: {{ .Values.whisk.versions.cli | quote }}
+  whisk_info_date: {{ .Values.whisk.versions.openwhisk.buildDate | quote }}
+  whisk_info_buildNo: {{ .Values.whisk.versions.openwhisk.buildNo | quote }}
+  whisk_cli_version_tag: {{ .Values.whisk.versions.openwhiskCli.tag | quote }}
   whisk_system_namespace: {{ .Values.whisk.systemNameSpace | quote }}
 {{- if eq .Values.whisk.ingress.type "LoadBalancer" }}
   whisk_api_host_proto: "https"

--- a/helm/openwhisk/templates/provider-alarm-pod.yaml
+++ b/helm/openwhisk/templates/provider-alarm-pod.yaml
@@ -34,8 +34,8 @@ spec:
 {{ include "openwhisk.readiness.waitForController" . | indent 6 }}
       containers:
       - name: {{ .Values.providers.alarm.name | quote }}
+        image: "{{- .Values.providers.alarm.imageName -}}:{{- .Values.providers.alarm.imageTag -}}"
         imagePullPolicy: {{ .Values.providers.alarm.imagePullPolicy | quote }}
-        image: {{ .Values.providers.alarm.image | quote }}
         ports:
         - name: alarmprovider
           containerPort: {{ .Values.providers.alarm.apiPort }}

--- a/helm/openwhisk/templates/provider-cloudant-pod.yaml
+++ b/helm/openwhisk/templates/provider-cloudant-pod.yaml
@@ -34,8 +34,8 @@ spec:
 {{ include "openwhisk.readiness.waitForController" . | indent 6 }}
       containers:
       - name: {{ .Values.providers.cloudant.name | quote }}
+        image: "{{- .Values.providers.cloudant.imageName -}}:{{- .Values.providers.cloudant.imageTag -}}"
         imagePullPolicy: {{ .Values.providers.cloudant.imagePullPolicy | quote }}
-        image: {{ .Values.providers.cloudant.image | quote }}
         ports:
         - name: cludntprovider
           containerPort: {{ .Values.providers.cloudant.apiPort }}

--- a/helm/openwhisk/templates/provider-kafka-pod.yaml
+++ b/helm/openwhisk/templates/provider-kafka-pod.yaml
@@ -26,8 +26,8 @@ spec:
 {{ include "openwhisk.readiness.waitForController" . | indent 6 }}
       containers:
       - name: {{ .Values.providers.kafka.name | quote }}
+        image: "{{- .Values.providers.kafka.imageName -}}:{{- .Values.providers.kafka.imageTag -}}"
         imagePullPolicy: {{ .Values.providers.kafka.imagePullPolicy | quote }}
-        image: {{ .Values.providers.kafka.image | quote }}
         ports:
         - name: kafkaprovider
           containerPort: {{ .Values.providers.kafka.apiPort }}

--- a/helm/openwhisk/templates/redis-pod.yaml
+++ b/helm/openwhisk/templates/redis-pod.yaml
@@ -52,8 +52,8 @@ spec:
 
       containers:
         - name: redis
+          image: "{{- .Values.redis.imageName -}}:{{- .Values.redis.imageTag -}}"
           imagePullPolicy: {{ .Values.redis.imagePullPolicy | quote }}
-          image: {{ .Values.redis.image | quote }}
 {{- if .Values.k8s.persistence.enabled }}
           volumeMounts:
           - mountPath: /data

--- a/helm/openwhisk/templates/tests/package-checker-pod.yaml
+++ b/helm/openwhisk/templates/tests/package-checker-pod.yaml
@@ -19,7 +19,7 @@ spec:
       name: openwhisk-tests-package-checker-cm
   containers:
   - name: package-checker
-    image: {{ .Values.utility.scriptRunnerImage | quote }}
+    image: "{{- .Values.utility.scriptRunner.imageName -}}:{{- .Values.utility.scriptRunner.imageTag -}}"
     imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
     volumeMounts:
     - name: task-dir

--- a/helm/openwhisk/templates/tests/smoketest-pod.yaml
+++ b/helm/openwhisk/templates/tests/smoketest-pod.yaml
@@ -19,7 +19,7 @@ spec:
       name: openwhisk-tests-smoketest-cm
   containers:
   - name: smoketest
-    image: {{ .Values.utility.scriptRunnerImage | quote }}
+    image: "{{- .Values.utility.scriptRunner.imageName -}}:{{- .Values.utility.scriptRunner.imageTag -}}"
     imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
     volumeMounts:
     - name: task-dir

--- a/helm/openwhisk/templates/zookeeper-pod.yaml
+++ b/helm/openwhisk/templates/zookeeper-pod.yaml
@@ -45,7 +45,7 @@ spec:
 
       containers:
       - name: {{ .Values.zookeeper.name | quote }}
-        image: {{ .Values.zookeeper.image | quote }}
+        image: "{{- .Values.zookeeper.imageName -}}:{{- .Values.zookeeper.imageTag -}}"
         imagePullPolicy: {{ .Values.zookeeper.imagePullPolicy | quote }}
         command: ["/bin/bash", "-c", "hostname -s | cut -d'-' -f2 > {{ .Values.zookeeper.config.dataDir }}/myid; cat {{ .Values.zookeeper.config.dataDir }}/myid; cat /conf/zoo.cfg; zkServer.sh start-foreground"]
         ports:

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -31,16 +31,28 @@ whisk:
   auth:
     system: "789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP"
     guest: "23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP"
-  versions:
-    tag: "latest"
-    cli: "latest"
   systemNameSpace: "/whisk.system"
-  runtimes: "runtimes.json"
   loadbalancer:
     blackboxFraction: "10%"
     timeoutFactor: 2
   containerPool:
     userMemory: "2048m"
+  runtimes: "runtimes.json"
+  versions:
+    openwhisk:
+      buildDate: "2018-11-13-21:33:13Z"
+      buildNo: "20181113a"
+      gitTag: "775b757ac7555c8371a5e03497622531984bf4f4"
+    openwhiskCli:
+      tag: "2062905"
+    openwhiskCatalog:
+      gitTag: "3d6d69f3e2dba96c775d4b1a4d55b1fc158b1201"
+    openwhiskPackageAlarms:
+      gitTag: "d3598dd4279b2675953eb3cdd3665694d254ac05"
+    openwhiskPackageCloudant:
+      gitTag: "1c340b85d0b29a5d3f1fd0df487c4dd2f9a7349b"
+    openwhiskPackageKafka:
+      gitTag: "e242c13d05a11c4d2df5968e13ba1e0f3ef95c72"
 
 # Properties of the Kubernetes cluster on which OpenWhisk is being deployed
 k8s:
@@ -53,15 +65,17 @@ k8s:
 
 # Images used to run auxillary tasks/jobs
 utility:
-  ansibleRunnerImage: "openwhisk/ansible-runner:latest"
-  scriptRunnerImage: "openwhisk/script-runner:latest"
-  imagePullPolicy: "Always"
+  ansibleRunner:
+    imageName: "openwhisk/ansible-runner"
+    imageTag: "775b757"
+    imagePullPolicy: "IfNotPresent"
+  scriptRunner:
+    imageName: "openwhisk/script-runner"
+    imageTag: "775b757"
+    imagePullPolicy: "IfNotPresent"
 
 # Docker registry
 docker:
-  image:
-    prefix: "openwhisk"
-    tag: "latest"
   registry:
     name: ""
     username: ""
@@ -71,10 +85,11 @@ docker:
 zookeeper:
   external: false
   name: "zookeeper"
-  image: "zookeeper:3.4"
+  imageName: "zookeeper"
+  imageTag: "3.4"
+  imagePullPolicy: "IfNotPresent"
   # Note: Zookeeper's quorum protocol is designed to have an odd number of replicas.
   replicaCount: 1
-  imagePullPolicy: "IfNotPresent"
   restartPolicy: "Always"
   port: 2181
   serverPort: 2888
@@ -94,10 +109,11 @@ zookeeper:
 kafka:
   external: false
   name: "kafka"
-  image: "wurstmeister/kafka:0.11.0.1"
+  imageName: "wurstmeister/kafka"
+  imageTag: "0.11.0.1"
+  imagePullPolicy: "IfNotPresent"
   # NOTE: setting replicaCount > 1 will not work...actively being worked on.
   replicaCount: 1
-  imagePullPolicy: "IfNotPresent"
   restartPolicy: "Always"
   port: 9092
   persistence:
@@ -111,10 +127,11 @@ db:
   # This should always be true if external is false.
   wipeAndInit: true
   name: "couchdb"
-  image: "apache/couchdb:2.1"
+  imageName: "apache/couchdb"
+  imageTag: "2.1"
+  imagePullPolicy: "IfNotPresent"
   # NOTE: must be 1 (because initdb.sh enables single node mode)
   replicaCount: 1
-  imagePullPolicy: "IfNotPresent"
   restartPolicy: "Always"
   host: nil
   port: 5984
@@ -135,10 +152,11 @@ db:
 # Nginx configurations
 nginx:
   name: "nginx"
-  image: "nginx:1.11"
+  imageName: "nginx"
+  imageTag: "1.11"
+  imagePullPolicy: "IfNotPresent"
   # NOTE: setting replicaCount > 1 is not tested and may not work
   replicaCount: 1
-  imagePullPolicy: "IfNotPresent"
   restartPolicy: "Always"
   httpPort: 80
   httpsPort: 443
@@ -147,9 +165,10 @@ nginx:
 # Controller configurations
 controller:
   name: "controller"
-  image: "openwhisk/controller:latest"
+  imageName: "openwhisk/controller"
+  imageTag: "775b757"
+  imagePullPolicy: "IfNotPresent"
   replicaCount: 1
-  imagePullPolicy: "Always"
   restartPolicy: "Always"
   port: 8080
   options: ""
@@ -164,11 +183,11 @@ controller:
 # Invoker configurations
 invoker:
   name: "invoker"
-  image: "openwhisk/invoker:latest"
-  imagePullPolicy: "Always"
+  imageName: "openwhisk/invoker"
+  imageTag: "775b757"
+  imagePullPolicy: "IfNotPresent"
   restartPolicy: "Always"
   port: 8080
-  pullRuntimesImage: "openwhisk/ansible-runner:latest"
   options: ""
   jvmHeapMB: "512"
   jvmOptions: ""
@@ -180,7 +199,9 @@ invoker:
       replicaCount: 1
       agent:
         name: "invoker-agent"
-        image: "openwhisk/kube-invoker-agent:latest"
+        imageName: "openwhisk/kube-invoker-agent"
+        imageTag: "fa67042"
+        imagePullPolicy: "IfNotPresent"
         enabled: false
         port: 3233
   containerNetwork: "bridge"
@@ -189,10 +210,11 @@ invoker:
 # API Gateway configurations
 apigw:
   name: "apigateway"
-  image: "openwhisk/apigateway:latest"
+  imageName: "openwhisk/apigateway"
+  imageTag: "a996221"
+  imagePullPolicy: "IfNotPresent"
   # NOTE: setting replicaCount > 1 is not tested and may not work
   replicaCount: 1
-  imagePullPolicy: "Always"
   restartPolicy: "Always"
   apiPort: 9000
   mgmtPort: 8080
@@ -200,10 +222,11 @@ apigw:
 # Redis (used by apigateway)
 redis:
   name: "redis"
-  image: "redis:4.0"
+  imageName: "redis"
+  imageTag: "4.0"
+  imagePullPolicy: "IfNotPresent"
   # NOTE: setting replicaCount > 1 will not work; need to add redis cluster configuration
   replicaCount: 1
-  imagePullPolicy: "IfNotPresent"
   restartPolicy: "Always"
   port: 6379
   persistence:
@@ -225,10 +248,11 @@ providers:
   alarm:
     enabled: false
     name: "alarmprovider"
-    image: "openwhisk/alarmprovider:latest"
+    imageName: "openwhisk/alarmprovider"
+    imageTag: "1.10.2"
+    imagePullPolicy: "IfNotPresent"
     # NOTE: replicaCount > 1 doesn't work because of the PVC
     replicaCount: 1
-    imagePullPolicy: "Always"
     restartPolicy: "Always"
     apiPort: 8080
     dbPrefix: "alm"
@@ -239,10 +263,11 @@ providers:
   kafka:
     enabled: false
     name: "kafkaprovider"
-    image: "openwhisk/kafkaprovider:latest"
+    imageName: "openwhisk/kafkaprovider"
+    imageTag: "1.4.18"
+    imagePullPolicy: "IfNotPresent"
     # NOTE: setting replicaCount > 1 has not been tested and may not work
     replicaCount: 1
-    imagePullPolicy: "IfNotPresent"
     restartPolicy: "Always"
     apiPort: 8080
     dbPrefix: "kp"
@@ -250,10 +275,11 @@ providers:
   cloudant:
     enabled: false
     name: "cloudantprovider"
-    image: "openwhisk/cloudantprovider:latest"
+    imageName: "openwhisk/cloudantprovider"
+    imageTag: "1.7.1"
+    imagePullPolicy: "IfNotPresent"
     # NOTE: replicaCount > 1 doesn't work because of the PVC
     replicaCount: 1
-    imagePullPolicy: "Always"
     restartPolicy: "Always"
     apiPort: 8080
     dbPrefix: "cldt"


### PR DESCRIPTION
All docker images and git clone operations now take tags
that do not default to latest/master.  This will increase
the stability of the Helm chart "nightly builds" by allowing
us to have a more controlled following of upstream changes.

All version tags are defined in values.yaml to enable easy overrides.

Fixes #353