### PR TITLE
ingress cleanup: allow default value for httpsNodePort

### DIFF
--- a/helm/openwhisk/templates/nginx-svc.yaml
+++ b/helm/openwhisk/templates/nginx-svc.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   {{- if eq .Values.whisk.ingress.type "LoadBalancer" }}
   type: LoadBalancer
-  {{- else if .Values.nginx.httpsNodePort }}
+  {{- else if eq .Values.whisk.ingress.type "NodePort" }}
   type: NodePort
   {{- end }}
   selector:
@@ -20,7 +20,7 @@ spec:
     - port: {{ .Values.nginx.httpPort }}
       name: http
     - port: {{ .Values.nginx.httpsPort }}
-      {{- if .Values.nginx.httpsNodePort }}
+      {{- if eq .Values.whisk.ingress.type "NodePort" }}
       nodePort: {{ .Values.nginx.httpsNodePort }}
       {{- end }}
       name: https-api


### PR DESCRIPTION
Make usage of nginx.httpsNodePort templates conditional on
ingress.type being NodePort to enable a default value
for nginx.httpsNodePort to be defined.