### PR TITLE
xenial finally in production for TravisCI; remove group:edge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-# See https://github.com/travis-ci/travis-ci/issues/10212
-group: edge
-
 dist: xenial
 sudo: required
 


### PR DESCRIPTION
Now that xenial is in production for TravisCI, we don't need the group:edge label in .travis.yml file.  So remove it.