### PR TITLE
add delay in healthy invoker readiness check

### DIFF
--- a/helm/openwhisk/templates/_readiness.tpl
+++ b/helm/openwhisk/templates/_readiness.tpl
@@ -52,5 +52,5 @@
   env:
   - name: "READINESS_URL"
     value: "http://{{ include "openwhisk.controller_host" . }}:{{ .Values.controller.port }}/invokers/healthy/count"
-  command: ["sh", "-c", "echo 0 > /tmp/count.txt; while true; do echo 'waiting for healthy invoker'; wget -T 5 -qO /tmp/count.txt --no-check-certificate \"$READINESS_URL\"; NUM_HEALTHY_INVOKERS=$(cat /tmp/count.txt); if [ $NUM_HEALTHY_INVOKERS -gt 0 ]; then echo \"Success: there are $NUM_HEALTHY_INVOKERS healthy invokers\"; break; fi; echo '...not ready yet; sleeping 3 seconds before retry'; sleep 3; done;"]
+  command: ["sh", "-c", "echo 0 > /tmp/count.txt; while true; do echo 'waiting for healthy invoker'; wget -T 5 -qO /tmp/count.txt --no-check-certificate \"$READINESS_URL\"; NUM_HEALTHY_INVOKERS=$(cat /tmp/count.txt); if [ $NUM_HEALTHY_INVOKERS -gt 0 ]; then echo \"Success: there are $NUM_HEALTHY_INVOKERS healthy invokers\"; sleep 3; break; fi; echo '...not ready yet; sleeping 5 seconds before retry'; sleep 5; done;"]
 {{- end -}}


### PR DESCRIPTION
In TravisCI environments, we often see failures in jobs that
run "right after" there is an initial report of healthy invokers
by the controller.  Let's wait for a few seconds in the readiness
probe to see if it improves the odds of success of jobs that run
triggered on this readiness probe.