### PR TITLE
Enforce unique keys for whisk.system and guest namespaces

### DIFF
--- a/helm/openwhisk/configMapFiles/initCouchDB/initdb.sh
+++ b/helm/openwhisk/configMapFiles/initCouchDB/initdb.sh
@@ -7,10 +7,18 @@ pushd /openwhisk
     git checkout $OW_GIT_TAG_OPENWHISK
 popd
 
-# Copy the secrets whisk.auth.guest and whisk.auth.system into the cloned tree
-# overwriting the default values we cloned from git
+# Install the secrets whisk.auth.guest and whisk.auth.system into the cloned tree
+# after removing the defaults inherited from the checkout of openwhisk
+rm -f /openwhisk/ansible/files/auth.guest /openwhisk/ansible/files/auth.whisk.system
 cp -f /etc/whisk-auth/guest /openwhisk/ansible/files/auth.guest
 cp -f /etc/whisk-auth/system /openwhisk/ansible/files/auth.whisk.system
+
+# Sanity check: all subjects must have unique keys
+if cmp -s /openwhisk/ansible/files/auth.guest /openwhisk/ansible/files/auth.whisk.system; then
+    echo "FATAL ERROR: unable to initialize the OpenWhisk subjects database."
+    echo "Cannot use identical keys for whisk.auth.system and whisk.auth.guest."
+    exit 1
+fi
 
 # generate db_local.ini so the ansible jobs know how to access the database
 pushd /openwhisk/ansible

--- a/helm/openwhisk/configMapFiles/installPackages/myTask.sh
+++ b/helm/openwhisk/configMapFiles/installPackages/myTask.sh
@@ -13,6 +13,7 @@ export PROVIDER_DB_URL=$PROVIDER_DB_PROTOCOL://$PROVIDER_DB_USERNAME:$PROVIDER_D
 git clone https://github.com/apache/incubator-openwhisk openwhisk
 pushd openwhisk
     git checkout $OW_GIT_TAG_OPENWHISK
+    rm -f /openwhisk/ansible/files/auth.guest /openwhisk/ansible/files/auth.whisk.system
 popd
 
 # Setup env for installRouteMgmt.sh


### PR DESCRIPTION
Fixes #418

We require unique auth values for each subject. Check that the
whisk.auth.guest and whisk.auth.system keys are unique during
couchdb initialization and fail with a clear error message instead
of allowing an unusable system to be deployed.

Also add an explicit `rm` of the default keys right after the git clone
of the openwhisk repository in the install-packages job to make sure they
can't be used by mistake in some subsequent script operation.