### PR TITLE
Wskadmin pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,9 @@ If your deployment is not working, check our
 
 # Administering OpenWhisk
 
-[Wskadmin](https://github.com/apache/incubator-openwhisk/tree/master/tools/admin) is the tool to perform various administrative operations against an OpenWhisk deployment. 
-Since wskadmin requires credentials for direct access to the database (that is not normally accessible to the outside), it is deployed in a pod inside Kubernetes that is configured to access it. You can run `wskadmin` with `kubectl`. You need to know the namespace and the deployment name. 
+[Wskadmin](https://github.com/apache/incubator-openwhisk/tree/master/tools/admin) is the tool to perform various administrative operations against an OpenWhisk deployment.
+
+Since wskadmin requires credentials for direct access to the database (that is not normally accessible to the outside), it is deployed in a pod inside Kubernetes that is configured to access it. You can run `wskadmin` with `kubectl`. You need to know the namespace and the deployment name.
 
 You can then invoke it with:
 

--- a/README.md
+++ b/README.md
@@ -263,12 +263,12 @@ If your deployment is not working, check our
 
 [Wskadmin](https://github.com/apache/incubator-openwhisk/tree/master/tools/admin) is the tool to perform various administrative operations against an OpenWhisk deployment.
 
-Since wskadmin requires credentials for direct access to the database (that is not normally accessible to the outside), it is deployed in a pod inside Kubernetes that is configured to access it. You can run `wskadmin` with `kubectl`. You need to know the namespace and the deployment name.
+Since wskadmin requires credentials for direct access to the database (that is not normally accessible to the outside), it is deployed in a pod inside Kubernetes that is configured with the proper parameters. You can run `wskadmin` with `kubectl`. You need to use the `<namespace>` and the deployment `<name>` that you configured with `--namespace` and `--name` when deploying.
 
-You can then invoke it with:
+You can then invoke `wskadmin` with:
 
 ```
-kubectl -n <namespace> -ti <deployment> -- wskadmin <parameters>
+kubectl -n <namespace> -ti exec <name>-wskadmin -- wskadmin <parameters>
 ```
 
 For example, is your deployment name is `owdev` and the namespace is `openwhisk` you can list users in the `guest` namespace with:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ to both single-node and multi-node Kubernetes clusters.
 
 * [Prerequisites: Kubernetes and Helm](#prerequisites-kubernetes-and-helm)
 * [Deploying OpenWhisk](#deploying-openwhisk)
+* [Administering OpenWhisk](#administering-openwhisk)
 * [Development and Testing](#development-and-testing)
 * [Cleanup](#cleanup)
 * [Issues](#issues)
@@ -258,6 +259,25 @@ certificate` errors from the `wsk` CLI.
 If your deployment is not working, check our
 [troubleshooting guide](./docs/troubleshooting.md) for ideas.
 
+# Administering OpenWhisk
+
+[Wskadmin](https://github.com/apache/incubator-openwhisk/tree/master/tools/admin) is the tool to perform various administrative operations against an OpenWhisk deployment. 
+Since wskadmin requires credentials for direct access to the database (that is not normally accessible to the outside), it is deployed in a pod inside Kubernetes that is configured to access it. You can run `wskadmin` with `kubectl`. You need to know the namespace and the deployment name. 
+
+You can then invoke it with:
+
+```
+kubectl -n <namespace> -ti <deployment> -- wskadmin <parameters>
+```
+
+For example, is your deployment name is `owdev` and the namespace is `openwhisk` you can list users in the `guest` namespace with:
+
+```
+$ kubectl -n openwhisk  -ti exec owdev-wskadmin -- wskadmin user list guest
+23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
+```
+
+Check [here](https://github.com/apache/incubator-openwhisk/tree/master/tools/admin) for details about the available commands.
 
 # Development and Testing
 

--- a/helm/openwhisk/templates/wskadmin-pod.yaml
+++ b/helm/openwhisk/templates/wskadmin-pod.yaml
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-wskadmin
+  labels:
+    name: {{ .Release.Name }}-wskadmin
+{{ include "openwhisk.label_boilerplate" . | indent 4 }}
+spec:
+  restartPolicy: Always
+  containers:
+  - name: wskadmin
+    image: "{{- .Values.wskadmin.imageName -}}:{{- .Values.wskadmin.imageTag -}}"
+    imagePullPolicy: {{ .Values.wskadmin.imagePullPolicy | quote }}
+    command: ["/bin/bash", "-c", "tail -f /dev/null"]
+    env:
+    - name: "WHISK_LOGS_DIR"
+      value: "/var/log"
+      # Provider database configuration
+    {{- if .Values.providers.db.external }}
+    # Use an external CouchDB instance for the providers
+    - name: "DB_PROTOCOL"
+      value: {{ .Values.providers.db.protocol | quote }}
+    - name: "DB_HOST"
+      value: {{ .Values.providers.db.host | quote }}
+    - name: "DB_USERNAME"
+      value: {{ .Values.providers.db.username | quote }}
+    - name: "DB_PASSWORD"
+      value: {{ .Values.providers.db.password | quote }}
+    - name: "DB_PORT"
+      value: {{ .Values.providers.db.port | quote }}
+    {{- else }}
+    # Use the internally deployed CouchDB service for the providers
+    - name: "DB_HOST"
+      valueFrom:
+        configMapKeyRef:
+          name: {{ .Release.Name }}-db.config
+          key: db_host
+    - name: "DB_PROTOCOL"
+      valueFrom:
+        configMapKeyRef:
+          name: {{ .Release.Name }}-db.config
+          key: db_protocol
+    - name: "DB_PORT"
+      valueFrom:
+        configMapKeyRef:
+          name: {{ .Release.Name }}-db.config
+          key: db_port
+    - name: "DB_USERNAME"
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Release.Name }}-db.auth
+          key: db_username
+    - name: "DB_PASSWORD"
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Release.Name }}-db.auth
+          key: db_password
+    {{ end }}
+    - name: "DB_WHISK_ACTIONS"
+    {{- if .Values.providers.db.whisk_actions }}
+      value: {{ .Values.providers.db.whisk_actions }}
+    {{ else }}
+      valueFrom:
+          configMapKeyRef:
+            name: {{ .Release.Name }}-db.config
+            key: db_whisk_actions
+    {{ end }}
+    - name: "DB_WHISK_AUTHS"
+    {{- if .Values.providers.db.whisk_auths }}
+      value: {{ .Values.providers.db.whisk_auths }}
+    {{ else }}
+      valueFrom:
+        configMapKeyRef:
+          name: {{ .Release.Name }}-db.config
+          key: db_whisk_auths
+    {{ end }}
+    - name: "DB_WHISK_ACTIVATIONS"
+    {{- if .Values.providers.db.whisk_activations }}
+      value: {{ .Values.providers.db.whisk_activations }}
+    {{ else }}
+      valueFrom:
+          configMapKeyRef:
+              name: {{ .Release.Name }}-db.config
+              key: db_whisk_activations
+    {{ end }}

--- a/helm/openwhisk/templates/wskadmin-pod.yaml
+++ b/helm/openwhisk/templates/wskadmin-pod.yaml
@@ -12,8 +12,8 @@ spec:
   restartPolicy: Always
   containers:
   - name: wskadmin
-    image: "{{- .Values.wskadmin.imageName -}}:{{- .Values.wskadmin.imageTag -}}"
-    imagePullPolicy: {{ .Values.wskadmin.imagePullPolicy | quote }}
+    image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+    imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
     command: ["/bin/bash", "-c", "tail -f /dev/null"]
     env:
     - name: "WHISK_LOGS_DIR"

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -136,15 +136,14 @@ k8s:
 # Images used to run auxillary tasks/jobs
 utility:
   imageName: "openwhisk/ow-utils"
-  imageTag: "00fad95"
+  imageTag: "3a6f6a7"
   imagePullPolicy: "IfNotPresent"
 
 # Images used to run auxillary tasks/jobs
 wskadmin:
-  imageName: "actionloop/wskadmin"
-  imageTag: "latest"
+  imageName: "openwhisk/ow-utils"
+  imageTag: "3a6f6a7"
   imagePullPolicy: "IfNotPresent"
-
 
 # Docker registry
 docker:

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -139,12 +139,6 @@ utility:
   imageTag: "3a6f6a7"
   imagePullPolicy: "IfNotPresent"
 
-# Images used to run auxillary tasks/jobs
-wskadmin:
-  imageName: "openwhisk/ow-utils"
-  imageTag: "3a6f6a7"
-  imagePullPolicy: "IfNotPresent"
-
 # Docker registry
 docker:
   registry:

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -139,6 +139,13 @@ utility:
   imageTag: "00fad95"
   imagePullPolicy: "IfNotPresent"
 
+# Images used to run auxillary tasks/jobs
+wskadmin:
+  imageName: "actionloop/wskadmin"
+  imageTag: "latest"
+  imagePullPolicy: "IfNotPresent"
+
+
 # Docker registry
 docker:
   registry:


### PR DESCRIPTION
Adds a wskadmin pod to allow administering OpenWhisk with `kubectl` without exposing the database outsided of the cluster and without providing more credentials than those needed to deploy OpenWhisk itself.