### PR TITLE
Support enabling concurrency

### DIFF
--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -116,6 +116,9 @@ spec:
           - name: "CONFIG_whisk_docker_containerFactory_containerArgs_network"
             value: {{ .Values.invoker.containerFactory.networkConfig.name | quote }}
 
+          - name: "CONFIG_whisk_containerFactory_containerArgs_extraArgs_env_0"
+            value: "__OW_ALLOW_CONCURRENT={{ .Values.invoker.containerFactory.enableConcurrency }}"
+
           # Invoker name is the name of the node (DaemonSet) or pod (StatefulSet)
           - name: "INVOKER_NAME"
             valueFrom:

--- a/helm/openwhisk/values-metadata.yaml
+++ b/helm/openwhisk/values-metadata.yaml
@@ -1022,6 +1022,12 @@ invoker:
           value: "docker"
         - label: "kubernetes"
           value: "kubernetes"
+    enableConcurrency:
+      __metadata:
+        label: "Enable concurrency"
+        description: "Should the invoker pass `__OW_ALLOW_CONCURRENT=true` to action containers, enabling concurrent execution in supporting runtimes"
+        type: "boolean"
+        required: true
     networkConfig:
       name:
         __metadata:

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -245,6 +245,7 @@ invoker:
     dind: false
     useRunc: false
     impl: "docker"
+    enableConcurrency: false
     networkConfig:
       name: "bridge"
       dns:


### PR DESCRIPTION
:wave: 

This enables users to easily enable concurrency via their `values.yaml`.

(I literally just signed the CLA minutes ago, so it definitely hasn't been processed yet.)