### PR TITLE
Add Support to store Openwhisk Component Images in Hosted Docker Registry.

### DIFF
--- a/docs/private-docker-registry.md
+++ b/docs/private-docker-registry.md
@@ -1,0 +1,79 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+# Using private docker registry
+
+By default, helm charts currently use docker hub to download images to deploy openwhisk components on kubernetes. If your Kubernetes provider does not allow public docker registry, you can use your hosted docker image registry to deploy openwhisk on kubernetes.
+
+- All openwhisk images should be uploaded to your hosted docker registry server.
+  - openwhisk/apigateway
+  - apache/couchdb
+  - openwhisk/controller
+  - openwhisk/invoker
+  - wurstmeister/kafka
+  - openwhisk/ow-utils
+  - zookeeper
+  - nginx
+  - redis
+  - busybox
+  - openwhisk/alarmprovider
+  - openwhisk/kafkaprovider
+  - openwhisk/cloudantprovider
+
+- Add details of your docker registry information in mycluster.yml and enable *usePrivateRegistry*.
+
+  ```yaml
+  docker:
+    registry:
+      name: "registry-name/"
+      username: username
+      password: "Passowrd"
+    usePrivateRegistry: true
+  ```
+
+  > - enabling usePrivateRegisrty will cause all your images to be pulled from private docker registry only.
+  > - Append / in your docker registry name.
+
+Enabling *usePrivateRegisty* will create a docker-registry secret as *{ReleaseName}-private-registry.auth* in kubernetes which will be used in pod/jobs as *imagePullSecrets*.
+
+```yaml
+# If ReleaseName is owdev and namespace is openwhisk
+# kubectl get secrets owdev-private-registry.auth -o yaml
+
+apiVersion: v1
+data:
+  .dockerconfigjson: <Base64 encoded>
+kind: Secret
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{".dockerconfigjson":"Base64 Encoded"},"kind":"Secret","metadata":{"annotations":{},"labels":{"app":"owdev-openwhisk","chart":"openwhisk-0.1.4","heritage":"Tiller","release":"owdev"},"name":"owdev-private-registry.auth","namespace":"openwhisk"},"type":"kubernetes.io/dockerconfigjson"}
+  creationTimestamp: "2019-04-04T06:44:43Z"
+  labels:
+    app: owdev-openwhisk
+    chart: openwhisk-0.1.4
+    heritage: Tiller
+    release: owdev
+  name: owdev-private-registry.auth
+  namespace: openwhisk
+  resourceVersion: "18273580"
+  selfLink: /api/v1/namespaces/openwhisk/secrets/owdev-private-registry.auth
+  uid: 20f03275-56a5-11e9-9164-005056a3e755
+type: kubernetes.io/dockerconfigjson
+```

--- a/docs/private-docker-registry.md
+++ b/docs/private-docker-registry.md
@@ -19,7 +19,7 @@
 
 # Using private docker registry
 
-By default, helm charts currently use docker hub to download images to deploy openwhisk components on kubernetes. If your Kubernetes provider does not allow public docker registry, you can use your hosted docker image registry to deploy openwhisk on kubernetes.
+By default, helm charts currently use docker hub to download images to deploy OpenWhisk components on Kubernetes. If your Kubernetes provider does not allow public docker registry, you can use your hosted docker image registry to deploy OpenWhisk on Kubernetes.
 
 - All openwhisk images should be uploaded to your hosted docker registry server.
   - openwhisk/apigateway
@@ -49,7 +49,7 @@ By default, helm charts currently use docker hub to download images to deploy op
   > - enabling registry information will cause all your images to be pulled from private docker registry only.
   > - Append / in your docker registry name.
 
-Enabling *registry.name* will create a docker-registry secret as *{ReleaseName}-private-registry.auth* in kubernetes which will be used in pod/jobs as *imagePullSecrets*.
+Enabling *registry.name* will create a docker-registry secret as *{ReleaseName}-private-registry.auth* in Kubernetes which will be used in pod/jobs as *imagePullSecrets*.
 
 ```yaml
 # If ReleaseName is owdev and namespace is openwhisk

--- a/docs/private-docker-registry.md
+++ b/docs/private-docker-registry.md
@@ -36,7 +36,7 @@ By default, helm charts currently use docker hub to download images to deploy op
   - openwhisk/kafkaprovider
   - openwhisk/cloudantprovider
 
-- Add details of your docker registry information in mycluster.yml and enable *usePrivateRegistry*.
+- Add details of your docker registry information in mycluster.yml.
 
   ```yaml
   docker:
@@ -44,13 +44,12 @@ By default, helm charts currently use docker hub to download images to deploy op
       name: "registry-name/"
       username: username
       password: "Passowrd"
-    usePrivateRegistry: true
   ```
 
-  > - enabling usePrivateRegisrty will cause all your images to be pulled from private docker registry only.
+  > - enabling registry information will cause all your images to be pulled from private docker registry only.
   > - Append / in your docker registry name.
 
-Enabling *usePrivateRegisty* will create a docker-registry secret as *{ReleaseName}-private-registry.auth* in kubernetes which will be used in pod/jobs as *imagePullSecrets*.
+Enabling *registry.name* will create a docker-registry secret as *{ReleaseName}-private-registry.auth* in kubernetes which will be used in pod/jobs as *imagePullSecrets*.
 
 ```yaml
 # If ReleaseName is owdev and namespace is openwhisk

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -198,7 +198,15 @@ app: {{ template "openwhisk.fullname" . }}
 
 {{/* Create imagePullSecrets for private docker-registry*/}}
 {{- define "openwhisk.dockerRegistrySecret" -}}
-{{- if .Values.docker.usePrivateRegistry }}
+{{- if ne .Values.docker.registry.name "" }}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.docker.registry.name (printf "%s:%s" .Values.docker.registry.username .Values.docker.registry.password | b64enc) | b64enc }}
+{{- end }}
+{{- end -}}
+
+{{/* ImagePullSecrets in pods and job*/}}
+{{- define "openwhisk.docker.imagePullSecrets" -}}
+{{- if ne .Values.docker.registry.name "" }}
+imagePullSecrets:
+- name: {{ .Release.Name }}-private-registry.auth
 {{- end }}
 {{- end -}}

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -195,3 +195,10 @@ app: {{ template "openwhisk.fullname" . }}
 {{- define "openwhisk.tls_secret_name" -}}
 {{ .Values.whisk.ingress.tls.secretname | default "ow-ingress-tls-secret" | quote }}
 {{- end -}}
+
+{{/* Create imagePullSecrets for private docker-registry*/}}
+{{- define "openwhisk.dockerRegistrySecret" -}}
+{{- if .Values.docker.usePrivateRegistry }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.docker.registry.name (printf "%s:%s" .Values.docker.registry.username .Values.docker.registry.password | b64enc) | b64enc }}
+{{- end }}
+{{- end -}}

--- a/helm/openwhisk/templates/_invoker-helpers.tpl
+++ b/helm/openwhisk/templates/_invoker-helpers.tpl
@@ -33,11 +33,7 @@
 
 {{- define "openwhisk.docker_pull_runtimes" -}}
 - name: docker-pull-runtimes
-{{- if .Values.docker.usePrivateRegistry }}
   image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- else }}
-  image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- end }}
   imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
   command: ["/usr/local/bin/ansible-playbook", "/invoker-scripts/playbook.yml"]
   volumeMounts:

--- a/helm/openwhisk/templates/_invoker-helpers.tpl
+++ b/helm/openwhisk/templates/_invoker-helpers.tpl
@@ -33,8 +33,12 @@
 
 {{- define "openwhisk.docker_pull_runtimes" -}}
 - name: docker-pull-runtimes
-  imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
+{{- if .Values.docker.usePrivateRegistry }}
+  image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- else }}
   image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- end }}
+  imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
   command: ["/usr/local/bin/ansible-playbook", "/invoker-scripts/playbook.yml"]
   volumeMounts:
   - name: dockersock

--- a/helm/openwhisk/templates/_readiness.tpl
+++ b/helm/openwhisk/templates/_readiness.tpl
@@ -7,11 +7,7 @@
 # if not db.wipeAndInit, the external db must already be ready; so no need for init container
 {{- else -}}
 - name: "wait-for-couchdb"
-{{- if .Values.docker.usePrivateRegistry }}
   image: "{{- .Values.docker.registry.name -}}busybox"
-{{- else }}
-  image: "busybox"
-{{- end }}
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"
@@ -23,11 +19,7 @@
 {{/* Init container that waits for kafka to be ready */}}
 {{- define "openwhisk.readiness.waitForKafka" -}}
 - name: "wait-for-kafka"
-{{- if .Values.docker.usePrivateRegistry }}
   image: "{{- .Values.docker.registry.name -}}busybox"
-{{- else }}
-  image: "busybox"
-{{- end }}
   imagePullPolicy: "IfNotPresent"
   # TODO: I haven't found an easy external test to determine that kafka is up, so as a hack we wait for zookeeper and then sleep for 10 seconds and cross our fingers!
   command: ["sh", "-c", 'result=1; until [ $result -eq 0 ]; do OK=$(echo ruok | nc -w 1 {{ include "openwhisk.zookeeper_zero_host" . }} {{ .Values.zookeeper.port }}); if [ "$OK" == "imok" ]; then result=0; echo "zookeeper returned imok!"; else echo waiting for zookeeper to be ready; sleep 1; fi done; echo "Zookeeper is up; will wait for 10 seconds to give kafka time to initialize"; sleep 10;']
@@ -36,11 +28,7 @@
 {{/* Init container that waits for zookeeper to be ready */}}
 {{- define "openwhisk.readiness.waitForZookeeper" -}}
 - name: "wait-for-zookeeper"
-{{- if .Values.docker.usePrivateRegistry }}
   image: "{{- .Values.docker.registry.name -}}busybox"
-{{- else }}
-  image: "busybox"
-{{- end }}
   imagePullPolicy: "IfNotPresent"
   command: ["sh", "-c", 'result=1; until [ $result -eq 0 ]; do OK=$(echo ruok | nc -w 1 {{ include "openwhisk.zookeeper_zero_host" . }} {{ .Values.zookeeper.port }}); if [ "$OK" == "imok" ]; then result=0; echo "zookeeper returned imok!"; else echo waiting for zookeeper to be ready; sleep 1; fi; done; echo "Success: zookeeper is up"']
 {{- end -}}
@@ -48,11 +36,7 @@
 {{/* Init container that waits for controller to be ready */}}
 {{- define "openwhisk.readiness.waitForController" -}}
 - name: "wait-for-controller"
-{{- if .Values.docker.usePrivateRegistry }}
   image: "{{- .Values.docker.registry.name -}}busybox"
-{{- else }}
-  image: "busybox"
-{{- end }}
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"
@@ -63,11 +47,7 @@
 {{/* Init container that waits for at least 1 healthy invoker */}}
 {{- define "openwhisk.readiness.waitForHealthyInvoker" -}}
 - name: "wait-for-healthy-invoker"
-{{- if .Values.docker.usePrivateRegistry }}
   image: "{{- .Values.docker.registry.name -}}busybox"
-{{- else }}
-  image: "busybox"
-{{- end }}
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"

--- a/helm/openwhisk/templates/_readiness.tpl
+++ b/helm/openwhisk/templates/_readiness.tpl
@@ -7,7 +7,11 @@
 # if not db.wipeAndInit, the external db must already be ready; so no need for init container
 {{- else -}}
 - name: "wait-for-couchdb"
+{{- if .Values.docker.usePrivateRegistry }}
+  image: "{{- .Values.docker.registry.name -}}busybox"
+{{- else }}
   image: "busybox"
+{{- end }}
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"
@@ -19,7 +23,11 @@
 {{/* Init container that waits for kafka to be ready */}}
 {{- define "openwhisk.readiness.waitForKafka" -}}
 - name: "wait-for-kafka"
+{{- if .Values.docker.usePrivateRegistry }}
+  image: "{{- .Values.docker.registry.name -}}busybox"
+{{- else }}
   image: "busybox"
+{{- end }}
   imagePullPolicy: "IfNotPresent"
   # TODO: I haven't found an easy external test to determine that kafka is up, so as a hack we wait for zookeeper and then sleep for 10 seconds and cross our fingers!
   command: ["sh", "-c", 'result=1; until [ $result -eq 0 ]; do OK=$(echo ruok | nc -w 1 {{ include "openwhisk.zookeeper_zero_host" . }} {{ .Values.zookeeper.port }}); if [ "$OK" == "imok" ]; then result=0; echo "zookeeper returned imok!"; else echo waiting for zookeeper to be ready; sleep 1; fi done; echo "Zookeeper is up; will wait for 10 seconds to give kafka time to initialize"; sleep 10;']
@@ -28,7 +36,11 @@
 {{/* Init container that waits for zookeeper to be ready */}}
 {{- define "openwhisk.readiness.waitForZookeeper" -}}
 - name: "wait-for-zookeeper"
+{{- if .Values.docker.usePrivateRegistry }}
+  image: "{{- .Values.docker.registry.name -}}busybox"
+{{- else }}
   image: "busybox"
+{{- end }}
   imagePullPolicy: "IfNotPresent"
   command: ["sh", "-c", 'result=1; until [ $result -eq 0 ]; do OK=$(echo ruok | nc -w 1 {{ include "openwhisk.zookeeper_zero_host" . }} {{ .Values.zookeeper.port }}); if [ "$OK" == "imok" ]; then result=0; echo "zookeeper returned imok!"; else echo waiting for zookeeper to be ready; sleep 1; fi; done; echo "Success: zookeeper is up"']
 {{- end -}}
@@ -36,7 +48,11 @@
 {{/* Init container that waits for controller to be ready */}}
 {{- define "openwhisk.readiness.waitForController" -}}
 - name: "wait-for-controller"
+{{- if .Values.docker.usePrivateRegistry }}
+  image: "{{- .Values.docker.registry.name -}}busybox"
+{{- else }}
   image: "busybox"
+{{- end }}
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"
@@ -47,7 +63,11 @@
 {{/* Init container that waits for at least 1 healthy invoker */}}
 {{- define "openwhisk.readiness.waitForHealthyInvoker" -}}
 - name: "wait-for-healthy-invoker"
+{{- if .Values.docker.usePrivateRegistry }}
+  image: "{{- .Values.docker.registry.name -}}busybox"
+{{- else }}
   image: "busybox"
+{{- end }}
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"

--- a/helm/openwhisk/templates/apigateway-pod.yaml
+++ b/helm/openwhisk/templates/apigateway-pod.yaml
@@ -26,18 +26,11 @@ spec:
 {{ include "openwhisk.affinity.core" . | indent 8 }}
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-apigateway" .Release.Name ) | indent 8 }}
       {{- end }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
         - name: apigateway
           imagePullPolicy: {{ .Values.apigw.imagePullPolicy | quote }}
-{{- if .Values.docker.usePrivateRegistry }}
           image: "{{- .Values.docker.registry.name -}}{{- .Values.apigw.imageName -}}:{{- .Values.apigw.imageTag -}}"
-{{- else }}
-          image: "{{- .Values.apigw.imageName -}}:{{- .Values.apigw.imageTag -}}"
-{{- end }}
           ports:
           - name: mgmt
             containerPort: {{ .Values.apigw.mgmtPort }}

--- a/helm/openwhisk/templates/apigateway-pod.yaml
+++ b/helm/openwhisk/templates/apigateway-pod.yaml
@@ -26,11 +26,18 @@ spec:
 {{ include "openwhisk.affinity.core" . | indent 8 }}
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-apigateway" .Release.Name ) | indent 8 }}
       {{- end }}
-
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
         - name: apigateway
           imagePullPolicy: {{ .Values.apigw.imagePullPolicy | quote }}
+{{- if .Values.docker.usePrivateRegistry }}
+          image: "{{- .Values.docker.registry.name -}}{{- .Values.apigw.imageName -}}:{{- .Values.apigw.imageTag -}}"
+{{- else }}
           image: "{{- .Values.apigw.imageName -}}:{{- .Values.apigw.imageTag -}}"
+{{- end }}
           ports:
           - name: mgmt
             containerPort: {{ .Values.apigw.mgmtPort }}

--- a/helm/openwhisk/templates/controller-pod.yaml
+++ b/helm/openwhisk/templates/controller-pod.yaml
@@ -34,11 +34,18 @@ spec:
       # The controller must wait for kafka and couchdb to be ready before it starts
 {{ include "openwhisk.readiness.waitForKafka" . | indent 6 }}
 {{ include "openwhisk.readiness.waitForCouchDB" . | indent 6 }}
-
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: controller
         imagePullPolicy: {{ .Values.controller.imagePullPolicy | quote }}
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.controller.imageName -}}:{{- .Values.controller.imageTag -}}"
+{{- else }}
         image: "{{- .Values.controller.imageName -}}:{{- .Values.controller.imageTag -}}"
+{{- end }}
         command: ["/bin/bash", "-c", "/init.sh `hostname | cut -d'-' -f3`"]
         ports:
         - name: controller

--- a/helm/openwhisk/templates/controller-pod.yaml
+++ b/helm/openwhisk/templates/controller-pod.yaml
@@ -34,18 +34,11 @@ spec:
       # The controller must wait for kafka and couchdb to be ready before it starts
 {{ include "openwhisk.readiness.waitForKafka" . | indent 6 }}
 {{ include "openwhisk.readiness.waitForCouchDB" . | indent 6 }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: controller
         imagePullPolicy: {{ .Values.controller.imagePullPolicy | quote }}
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.controller.imageName -}}:{{- .Values.controller.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.controller.imageName -}}:{{- .Values.controller.imageTag -}}"
-{{- end }}
         command: ["/bin/bash", "-c", "/init.sh `hostname | cut -d'-' -f3`"]
         ports:
         - name: controller

--- a/helm/openwhisk/templates/couchdb-init-job.yaml
+++ b/helm/openwhisk/templates/couchdb-init-job.yaml
@@ -26,9 +26,17 @@ spec:
       - name: whisk-auth
         secret:
           secretName: {{ .Release.Name }}-whisk.auth
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: init-couchdb
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- else }}
         image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- end }}
         imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
         command: ["/bin/bash", "-c", "set -e; . /task/initdb.sh"]
         volumeMounts:

--- a/helm/openwhisk/templates/couchdb-init-job.yaml
+++ b/helm/openwhisk/templates/couchdb-init-job.yaml
@@ -26,17 +26,10 @@ spec:
       - name: whisk-auth
         secret:
           secretName: {{ .Release.Name }}-whisk.auth
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: init-couchdb
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- end }}
         imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
         command: ["/bin/bash", "-c", "set -e; . /task/initdb.sh"]
         volumeMounts:

--- a/helm/openwhisk/templates/couchdb-pod.yaml
+++ b/helm/openwhisk/templates/couchdb-pod.yaml
@@ -27,10 +27,17 @@ spec:
 {{ include "openwhisk.affinity.core" . | indent 8 }}
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-couchdb" .Release.Name ) | indent 8 }}
       {{- end }}
-
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: couchdb
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.db.imageName -}}:{{- .Values.db.imageTag -}}"
+{{- else }}
         image: "{{- .Values.db.imageName -}}:{{- .Values.db.imageTag -}}"
+{{- end }}
         imagePullPolicy: {{ .Values.db.imagePullPolicy | quote }}
         ports:
         - name: couchdb

--- a/helm/openwhisk/templates/couchdb-pod.yaml
+++ b/helm/openwhisk/templates/couchdb-pod.yaml
@@ -27,17 +27,10 @@ spec:
 {{ include "openwhisk.affinity.core" . | indent 8 }}
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-couchdb" .Release.Name ) | indent 8 }}
       {{- end }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: couchdb
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.db.imageName -}}:{{- .Values.db.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.db.imageName -}}:{{- .Values.db.imageTag -}}"
-{{- end }}
         imagePullPolicy: {{ .Values.db.imagePullPolicy | quote }}
         ports:
         - name: couchdb

--- a/helm/openwhisk/templates/install-packages-job.yaml
+++ b/helm/openwhisk/templates/install-packages-job.yaml
@@ -24,17 +24,10 @@ spec:
           name: {{ .Release.Name }}-install-packages-cm
       initContainers:
 {{ include "openwhisk.readiness.waitForHealthyInvoker" . | indent 6 }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: install-packages
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- end }}
         imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
         command: ["/bin/bash", "-c", "set -e; . /task/myTask.sh"]
         volumeMounts:

--- a/helm/openwhisk/templates/install-packages-job.yaml
+++ b/helm/openwhisk/templates/install-packages-job.yaml
@@ -24,9 +24,17 @@ spec:
           name: {{ .Release.Name }}-install-packages-cm
       initContainers:
 {{ include "openwhisk.readiness.waitForHealthyInvoker" . | indent 6 }}
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: install-packages
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- else }}
         image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- end }}
         imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
         command: ["/bin/bash", "-c", "set -e; . /task/myTask.sh"]
         volumeMounts:

--- a/helm/openwhisk/templates/invoker-agent-pod.yaml
+++ b/helm/openwhisk/templates/invoker-agent-pod.yaml
@@ -36,10 +36,17 @@ spec:
       initContainers:
       # Pull images for all default runtimes before starting invoker
 {{ include "openwhisk.docker_pull_runtimes" . | indent 6 }}
-
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: invoker-agent
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.invoker.containerFactory.kubernetes.agent.imageName -}}:{{- .Values.invoker.containerFactory.kubernetes.agent.imageTag -}}"
+{{- else }}
         image: "{{- .Values.invoker.containerFactory.kubernetes.agent.imageName -}}:{{- .Values.invoker.containerFactory.kubernetes.agent.imageTag -}}"
+{{- end }}
         imagePullPolicy: {{ .Values.invoker.containerFactory.kubernetes.agent.imagePullPolicy | quote }}
         securityContext:
           privileged: true

--- a/helm/openwhisk/templates/invoker-agent-pod.yaml
+++ b/helm/openwhisk/templates/invoker-agent-pod.yaml
@@ -36,17 +36,10 @@ spec:
       initContainers:
       # Pull images for all default runtimes before starting invoker
 {{ include "openwhisk.docker_pull_runtimes" . | indent 6 }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: invoker-agent
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.invoker.containerFactory.kubernetes.agent.imageName -}}:{{- .Values.invoker.containerFactory.kubernetes.agent.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.invoker.containerFactory.kubernetes.agent.imageName -}}:{{- .Values.invoker.containerFactory.kubernetes.agent.imageTag -}}"
-{{- end }}
         imagePullPolicy: {{ .Values.invoker.containerFactory.kubernetes.agent.imagePullPolicy | quote }}
         securityContext:
           privileged: true

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -53,17 +53,10 @@ spec:
 {{- end }}
       # Wait for a controller to be up (which implies kafka, zookeeper, couchdb are all up as well).
 {{ include "openwhisk.readiness.waitForController" . | indent 6 }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: invoker
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.invoker.imageName -}}:{{- .Values.invoker.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.invoker.imageName -}}:{{- .Values.invoker.imageTag -}}"
-{{- end }}
         imagePullPolicy: {{ .Values.invoker.imagePullPolicy | quote }}
 {{- if and (eq .Values.invoker.containerFactory.impl "docker") .Values.invoker.containerFactory.networkConfig.dns.inheritInvokerConfig }}
         command: [ "/bin/bash", "-c", ". /invoker-scripts/configureDNS.sh && /init.sh --uniqueName $INVOKER_NAME" ]

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -53,10 +53,17 @@ spec:
 {{- end }}
       # Wait for a controller to be up (which implies kafka, zookeeper, couchdb are all up as well).
 {{ include "openwhisk.readiness.waitForController" . | indent 6 }}
-
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: invoker
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.invoker.imageName -}}:{{- .Values.invoker.imageTag -}}"
+{{- else }}
         image: "{{- .Values.invoker.imageName -}}:{{- .Values.invoker.imageTag -}}"
+{{- end }}
         imagePullPolicy: {{ .Values.invoker.imagePullPolicy | quote }}
 {{- if and (eq .Values.invoker.containerFactory.impl "docker") .Values.invoker.containerFactory.networkConfig.dns.inheritInvokerConfig }}
         command: [ "/bin/bash", "-c", ". /invoker-scripts/configureDNS.sh && /init.sh --uniqueName $INVOKER_NAME" ]

--- a/helm/openwhisk/templates/kafka-pod.yaml
+++ b/helm/openwhisk/templates/kafka-pod.yaml
@@ -38,17 +38,10 @@ spec:
 
       initContainers:
 {{ include "openwhisk.readiness.waitForZookeeper" . | indent 6 }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: kafka
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.kafka.imageName -}}:{{- .Values.kafka.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.kafka.imageName -}}:{{- .Values.kafka.imageTag -}}"
-{{- end }}
         imagePullPolicy: {{ .Values.kafka.imagePullPolicy | quote }}
 {{- if .Values.k8s.persistence.enabled }}
         volumeMounts:

--- a/helm/openwhisk/templates/kafka-pod.yaml
+++ b/helm/openwhisk/templates/kafka-pod.yaml
@@ -38,10 +38,17 @@ spec:
 
       initContainers:
 {{ include "openwhisk.readiness.waitForZookeeper" . | indent 6 }}
-
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: kafka
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.kafka.imageName -}}:{{- .Values.kafka.imageTag -}}"
+{{- else }}
         image: "{{- .Values.kafka.imageName -}}:{{- .Values.kafka.imageTag -}}"
+{{- end }}
         imagePullPolicy: {{ .Values.kafka.imagePullPolicy | quote }}
 {{- if .Values.k8s.persistence.enabled }}
         volumeMounts:

--- a/helm/openwhisk/templates/nginx-pod.yaml
+++ b/helm/openwhisk/templates/nginx-pod.yaml
@@ -36,18 +36,10 @@ spec:
           name: {{ .Release.Name }}-nginx
       - name: logs
         emptyDir: {}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: nginx
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.nginx.imageName -}}:{{- .Values.nginx.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.nginx.imageName -}}:{{- .Values.nginx.imageTag -}}"
-{{- end }}
-
         imagePullPolicy: {{ .Values.nginx.imagePullPolicy | quote }}
         ports:
         - name: http

--- a/helm/openwhisk/templates/nginx-pod.yaml
+++ b/helm/openwhisk/templates/nginx-pod.yaml
@@ -36,10 +36,18 @@ spec:
           name: {{ .Release.Name }}-nginx
       - name: logs
         emptyDir: {}
-
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: nginx
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.nginx.imageName -}}:{{- .Values.nginx.imageTag -}}"
+{{- else }}
         image: "{{- .Values.nginx.imageName -}}:{{- .Values.nginx.imageTag -}}"
+{{- end }}
+
         imagePullPolicy: {{ .Values.nginx.imagePullPolicy | quote }}
         ports:
         - name: http

--- a/helm/openwhisk/templates/private-registry-secret.yml
+++ b/helm/openwhisk/templates/private-registry-secret.yml
@@ -1,0 +1,14 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+{{- if .Values.docker.usePrivateRegistry }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-private-registry.auth
+  labels:
+{{ include "openwhisk.label_boilerplate" . | indent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "openwhisk.dockerRegistrySecret" . }}
+{{- end }}

--- a/helm/openwhisk/templates/private-registry-secret.yml
+++ b/helm/openwhisk/templates/private-registry-secret.yml
@@ -1,7 +1,7 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-{{- if .Values.docker.usePrivateRegistry }}
+{{- if ne .Values.docker.registry.name "" }}
 
 apiVersion: v1
 kind: Secret
@@ -13,4 +13,3 @@ type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "openwhisk.dockerRegistrySecret" . }}
 {{- end }}
-

--- a/helm/openwhisk/templates/private-registry-secret.yml
+++ b/helm/openwhisk/templates/private-registry-secret.yml
@@ -2,6 +2,7 @@
 # license agreements; and to You under the Apache License, Version 2.0.
 
 {{- if .Values.docker.usePrivateRegistry }}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "openwhisk.dockerRegistrySecret" . }}
 {{- end }}
+

--- a/helm/openwhisk/templates/private-registry-secret.yml
+++ b/helm/openwhisk/templates/private-registry-secret.yml
@@ -13,3 +13,4 @@ type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "openwhisk.dockerRegistrySecret" . }}
 {{- end }}
+

--- a/helm/openwhisk/templates/provider-alarm-pod.yaml
+++ b/helm/openwhisk/templates/provider-alarm-pod.yaml
@@ -32,9 +32,17 @@ spec:
       initContainers:
       # Wait for a controller to be up (which implies couchdb is up as well).
 {{ include "openwhisk.readiness.waitForController" . | indent 6 }}
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: alarmprovider
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.providers.alarm.imageName -}}:{{- .Values.providers.alarm.imageTag -}}"
+{{- else }}
         image: "{{- .Values.providers.alarm.imageName -}}:{{- .Values.providers.alarm.imageTag -}}"
+{{- end }}
         imagePullPolicy: {{ .Values.providers.alarm.imagePullPolicy | quote }}
         ports:
         - name: alarmprovider

--- a/helm/openwhisk/templates/provider-alarm-pod.yaml
+++ b/helm/openwhisk/templates/provider-alarm-pod.yaml
@@ -32,17 +32,10 @@ spec:
       initContainers:
       # Wait for a controller to be up (which implies couchdb is up as well).
 {{ include "openwhisk.readiness.waitForController" . | indent 6 }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: alarmprovider
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.providers.alarm.imageName -}}:{{- .Values.providers.alarm.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.providers.alarm.imageName -}}:{{- .Values.providers.alarm.imageTag -}}"
-{{- end }}
         imagePullPolicy: {{ .Values.providers.alarm.imagePullPolicy | quote }}
         ports:
         - name: alarmprovider

--- a/helm/openwhisk/templates/provider-cloudant-pod.yaml
+++ b/helm/openwhisk/templates/provider-cloudant-pod.yaml
@@ -32,17 +32,10 @@ spec:
       initContainers:
       # Wait for a controller to be up (which implies couchdb is up as well).
 {{ include "openwhisk.readiness.waitForController" . | indent 6 }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: cloudantprovider
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.providers.cloudant.imageName -}}:{{- .Values.providers.cloudant.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.providers.cloudant.imageName -}}:{{- .Values.providers.cloudant.imageTag -}}"
-{{- end }}
         imagePullPolicy: {{ .Values.providers.cloudant.imagePullPolicy | quote }}
         ports:
         - name: cludntprovider

--- a/helm/openwhisk/templates/provider-cloudant-pod.yaml
+++ b/helm/openwhisk/templates/provider-cloudant-pod.yaml
@@ -32,9 +32,17 @@ spec:
       initContainers:
       # Wait for a controller to be up (which implies couchdb is up as well).
 {{ include "openwhisk.readiness.waitForController" . | indent 6 }}
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: cloudantprovider
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.providers.cloudant.imageName -}}:{{- .Values.providers.cloudant.imageTag -}}"
+{{- else }}
         image: "{{- .Values.providers.cloudant.imageName -}}:{{- .Values.providers.cloudant.imageTag -}}"
+{{- end }}
         imagePullPolicy: {{ .Values.providers.cloudant.imagePullPolicy | quote }}
         ports:
         - name: cludntprovider

--- a/helm/openwhisk/templates/provider-kafka-pod.yaml
+++ b/helm/openwhisk/templates/provider-kafka-pod.yaml
@@ -24,9 +24,17 @@ spec:
       initContainers:
       # Wait for a controller to be up (which implies couchdb and kafka are up as well).
 {{ include "openwhisk.readiness.waitForController" . | indent 6 }}
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: kafkaprovider
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.providers.kafka.imageName -}}:{{- .Values.providers.kafka.imageTag -}}"
+{{- else }}
         image: "{{- .Values.providers.kafka.imageName -}}:{{- .Values.providers.kafka.imageTag -}}"
+{{- end }}
         imagePullPolicy: {{ .Values.providers.kafka.imagePullPolicy | quote }}
         ports:
         - name: kafkaprovider

--- a/helm/openwhisk/templates/provider-kafka-pod.yaml
+++ b/helm/openwhisk/templates/provider-kafka-pod.yaml
@@ -24,17 +24,10 @@ spec:
       initContainers:
       # Wait for a controller to be up (which implies couchdb and kafka are up as well).
 {{ include "openwhisk.readiness.waitForController" . | indent 6 }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: kafkaprovider
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.providers.kafka.imageName -}}:{{- .Values.providers.kafka.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.providers.kafka.imageName -}}:{{- .Values.providers.kafka.imageTag -}}"
-{{- end }}
         imagePullPolicy: {{ .Values.providers.kafka.imagePullPolicy | quote }}
         ports:
         - name: kafkaprovider

--- a/helm/openwhisk/templates/redis-pod.yaml
+++ b/helm/openwhisk/templates/redis-pod.yaml
@@ -37,7 +37,11 @@ spec:
 {{- if .Values.k8s.persistence.enabled }}
       initContainers:
       - name: redis-init
-        image: busybox
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}busybox"
+{{- else }}
+        image: "busybox"
+{{- end }}
         command:
           - chown
           - -v
@@ -49,10 +53,17 @@ spec:
           name: redis-data
           readOnly: false
 {{- end }}
-
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
         - name: redis
+{{- if .Values.docker.usePrivateRegistry }}
+          image: "{{- .Values.docker.registry.name -}}{{- .Values.redis.imageName -}}:{{- .Values.redis.imageTag -}}"
+{{- else }}
           image: "{{- .Values.redis.imageName -}}:{{- .Values.redis.imageTag -}}"
+{{- end }}
           imagePullPolicy: {{ .Values.redis.imagePullPolicy | quote }}
 {{- if .Values.k8s.persistence.enabled }}
           volumeMounts:

--- a/helm/openwhisk/templates/redis-pod.yaml
+++ b/helm/openwhisk/templates/redis-pod.yaml
@@ -53,17 +53,10 @@ spec:
           name: redis-data
           readOnly: false
 {{- end }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
         - name: redis
-{{- if .Values.docker.usePrivateRegistry }}
           image: "{{- .Values.docker.registry.name -}}{{- .Values.redis.imageName -}}:{{- .Values.redis.imageTag -}}"
-{{- else }}
-          image: "{{- .Values.redis.imageName -}}:{{- .Values.redis.imageTag -}}"
-{{- end }}
           imagePullPolicy: {{ .Values.redis.imagePullPolicy | quote }}
 {{- if .Values.k8s.persistence.enabled }}
           volumeMounts:

--- a/helm/openwhisk/templates/redis-pod.yaml
+++ b/helm/openwhisk/templates/redis-pod.yaml
@@ -37,11 +37,7 @@ spec:
 {{- if .Values.k8s.persistence.enabled }}
       initContainers:
       - name: redis-init
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}busybox"
-{{- else }}
-        image: "busybox"
-{{- end }}
         command:
           - chown
           - -v

--- a/helm/openwhisk/templates/tests/package-checker-pod.yaml
+++ b/helm/openwhisk/templates/tests/package-checker-pod.yaml
@@ -17,17 +17,10 @@ spec:
   - name: task-dir
     configMap:
       name: {{ .Release.Name }}-tests-package-checker
-{{- if .Values.docker.usePrivateRegistry }}
-  imagePullSecrets:
-  - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 2 }}
   containers:
   - name: package-checker
-{{- if .Values.docker.usePrivateRegistry }}
     image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- else }}
-    image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- end }}
     imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
     command: ["/bin/bash", "/task/myTask.sh"]
     volumeMounts:

--- a/helm/openwhisk/templates/tests/package-checker-pod.yaml
+++ b/helm/openwhisk/templates/tests/package-checker-pod.yaml
@@ -17,9 +17,17 @@ spec:
   - name: task-dir
     configMap:
       name: {{ .Release.Name }}-tests-package-checker
+{{- if .Values.docker.usePrivateRegistry }}
+  imagePullSecrets:
+  - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
   containers:
   - name: package-checker
+{{- if .Values.docker.usePrivateRegistry }}
+    image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- else }}
     image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- end }}
     imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
     command: ["/bin/bash", "/task/myTask.sh"]
     volumeMounts:

--- a/helm/openwhisk/templates/tests/smoketest-pod.yaml
+++ b/helm/openwhisk/templates/tests/smoketest-pod.yaml
@@ -17,9 +17,17 @@ spec:
   - name: task-dir
     configMap:
       name: {{ .Release.Name }}-tests-smoketest
+{{- if .Values.docker.usePrivateRegistry }}
+  imagePullSecrets:
+  - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
   containers:
   - name: smoketest
+{{- if .Values.docker.usePrivateRegistry }}
+    image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- else }}
     image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- end }}
     imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
     command: ["/bin/bash", "/task/myTask.sh"]
     volumeMounts:

--- a/helm/openwhisk/templates/tests/smoketest-pod.yaml
+++ b/helm/openwhisk/templates/tests/smoketest-pod.yaml
@@ -17,17 +17,10 @@ spec:
   - name: task-dir
     configMap:
       name: {{ .Release.Name }}-tests-smoketest
-{{- if .Values.docker.usePrivateRegistry }}
-  imagePullSecrets:
-  - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 2 }}
   containers:
   - name: smoketest
-{{- if .Values.docker.usePrivateRegistry }}
     image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- else }}
-    image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- end }}
     imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
     command: ["/bin/bash", "/task/myTask.sh"]
     volumeMounts:

--- a/helm/openwhisk/templates/tests/systemtest-pod.yaml
+++ b/helm/openwhisk/templates/tests/systemtest-pod.yaml
@@ -18,17 +18,10 @@ spec:
   - name: task-dir
     configMap:
       name: {{ .Release.Name }}-tests-systemtest
-{{- if .Values.docker.usePrivateRegistry }}
-  imagePullSecrets:
-  - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 2 }}
   containers:
   - name: systemtest
-{{- if .Values.docker.usePrivateRegistry }}
     image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- else }}
-    image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- end }}
     imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
     command: ["/bin/bash", "/task/myTask.sh"]
     volumeMounts:

--- a/helm/openwhisk/templates/tests/systemtest-pod.yaml
+++ b/helm/openwhisk/templates/tests/systemtest-pod.yaml
@@ -18,9 +18,17 @@ spec:
   - name: task-dir
     configMap:
       name: {{ .Release.Name }}-tests-systemtest
+{{- if .Values.docker.usePrivateRegistry }}
+  imagePullSecrets:
+  - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
   containers:
   - name: systemtest
+{{- if .Values.docker.usePrivateRegistry }}
+    image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- else }}
     image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- end }}
     imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
     command: ["/bin/bash", "/task/myTask.sh"]
     volumeMounts:

--- a/helm/openwhisk/templates/wskadmin-pod.yaml
+++ b/helm/openwhisk/templates/wskadmin-pod.yaml
@@ -10,17 +10,10 @@ metadata:
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
 spec:
   restartPolicy: Always
-{{- if .Values.docker.usePrivateRegistry }}
-  imagePullSecrets:
-  - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 2 }}
   containers:
   - name: wskadmin
-{{- if .Values.docker.usePrivateRegistry }}
     image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- else }}
-    image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
-{{- end }}
     imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
     command: ["/bin/bash", "-c", "tail -f /dev/null"]
     env:

--- a/helm/openwhisk/templates/wskadmin-pod.yaml
+++ b/helm/openwhisk/templates/wskadmin-pod.yaml
@@ -10,9 +10,17 @@ metadata:
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
 spec:
   restartPolicy: Always
+{{- if .Values.docker.usePrivateRegistry }}
+  imagePullSecrets:
+  - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
   containers:
   - name: wskadmin
+{{- if .Values.docker.usePrivateRegistry }}
+    image: "{{- .Values.docker.registry.name -}}{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- else }}
     image: "{{- .Values.utility.imageName -}}:{{- .Values.utility.imageTag -}}"
+{{- end }}
     imagePullPolicy: {{ .Values.utility.imagePullPolicy | quote }}
     command: ["/bin/bash", "-c", "tail -f /dev/null"]
     env:

--- a/helm/openwhisk/templates/zookeeper-pod.yaml
+++ b/helm/openwhisk/templates/zookeeper-pod.yaml
@@ -41,17 +41,10 @@ spec:
           persistentVolumeClaim:
             claimName: "{{ .Release.Name }}-zookeeper-pvc-datalog"
 {{- end }}
-{{- if .Values.docker.usePrivateRegistry }}
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-private-registry.auth
-{{- end }}
+{{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: zookeeper
-{{- if .Values.docker.usePrivateRegistry }}
         image: "{{- .Values.docker.registry.name -}}{{- .Values.zookeeper.imageName -}}:{{- .Values.zookeeper.imageTag -}}"
-{{- else }}
-        image: "{{- .Values.zookeeper.imageName -}}:{{- .Values.zookeeper.imageTag -}}"
-{{- end }}
         imagePullPolicy: {{ .Values.zookeeper.imagePullPolicy | quote }}
         command: ["/bin/bash", "-c", "hostname -s | cut -d'-' -f3 > {{ .Values.zookeeper.config.dataDir }}/myid; cat {{ .Values.zookeeper.config.dataDir }}/myid; cat /conf/zoo.cfg; zkServer.sh start-foreground"]
         ports:

--- a/helm/openwhisk/templates/zookeeper-pod.yaml
+++ b/helm/openwhisk/templates/zookeeper-pod.yaml
@@ -41,10 +41,17 @@ spec:
           persistentVolumeClaim:
             claimName: "{{ .Release.Name }}-zookeeper-pvc-datalog"
 {{- end }}
-
+{{- if .Values.docker.usePrivateRegistry }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-private-registry.auth
+{{- end }}
       containers:
       - name: zookeeper
+{{- if .Values.docker.usePrivateRegistry }}
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.zookeeper.imageName -}}:{{- .Values.zookeeper.imageTag -}}"
+{{- else }}
         image: "{{- .Values.zookeeper.imageName -}}:{{- .Values.zookeeper.imageTag -}}"
+{{- end }}
         imagePullPolicy: {{ .Values.zookeeper.imagePullPolicy | quote }}
         command: ["/bin/bash", "-c", "hostname -s | cut -d'-' -f3 > {{ .Values.zookeeper.config.dataDir }}/myid; cat {{ .Values.zookeeper.config.dataDir }}/myid; cat /conf/zoo.cfg; zkServer.sh start-foreground"]
         ports:
@@ -58,17 +65,16 @@ spec:
         livenessProbe:
           tcpSocket:
             port: {{ .Values.zookeeper.port }}
-            initialDelaySeconds: 5
-            periodSeconds: 10
+          initialDelaySeconds: 5
+          periodSeconds: 10
         readinessProbe:
           exec:
             command:
             - /bin/bash
             - -c
             - "echo ruok | nc -w 1 localhost:{{ .Values.zookeeper.port }} | grep imok"
-            initialDelaySeconds: 5
-            periodSeconds: 10
-
+          initialDelaySeconds: 5
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /conf
           name: zk-config

--- a/helm/openwhisk/values-metadata.yaml
+++ b/helm/openwhisk/values-metadata.yaml
@@ -519,6 +519,12 @@ docker:
       description: "The timezone to use when performing Docker operations"
       type: "string"
       required: false
+  usePrivateRegistry:
+    __metadata:
+      label: "Use Private Registry as Docker Image Repository"
+      description: "If enabled, all images will be pulled from Private Docker Registry"
+      type: "boolean"
+      required: false
 
 zookeeper:
   __metadata:

--- a/helm/openwhisk/values-metadata.yaml
+++ b/helm/openwhisk/values-metadata.yaml
@@ -519,12 +519,6 @@ docker:
       description: "The timezone to use when performing Docker operations"
       type: "string"
       required: false
-  usePrivateRegistry:
-    __metadata:
-      label: "Use Private Registry as Docker Image Repository"
-      description: "If enabled, all images will be pulled from Private Docker Registry"
-      type: "boolean"
-      required: false
 
 zookeeper:
   __metadata:

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -146,7 +146,6 @@ docker:
     username: ""
     password: ""
   timezone: "UTC"
-  usePrivateRegistry: false
 
 # zookeeper configurations
 zookeeper:

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -146,6 +146,7 @@ docker:
     username: ""
     password: ""
   timezone: "UTC"
+  usePrivateRegistry: false
 
 # zookeeper configurations
 zookeeper:


### PR DESCRIPTION
<!--
We use the issue tracker for bugs and feature requests. For general questions and discussion please use http://slack.openwhisk.org/ or https://openwhisk.apache.org/contact.html instead.

Do NOT share passwords, credentials or other confidential information.

Before creating a new issue, please check if there is one already open that
fits the defect you are reporting.
If you open an issue and realize later it is a duplicate of a pre-existing
the open issue, please close yours and add a comment to the other.

Issues can be created for either defects or enhancement requests. If you are a committer than please add the labels "bug" or "feature". If you are not a committer please make clear in the comments which one it is, so that committers can add these labels later.

If you are reporting a defect, please edit the issue description to include the
information is shown below.

If you are reporting an enhancement request, please include information on what you are trying to achieve and why that enhancement would help you.

For more information about reporting issues, see
https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md#raising-issues

Use the commands below to provide key information from your environment:
You do not have to include this information if this is a feature request.
-->

## Description 

Currently, Private/Hosted Docker registry values are only used for installing the runtime images from playbook.yml on invoker pod. 

This PR is to support a scenario where we need to use our Hosted Docker registry to store Openwhisk Images as well for like invoker, controller, etc and only allowed to use Hosted Docker Repository (Artifactory) by Kubernetes Cluster provider (in our case Hosted Kubernetes Deployment). 

Furthermore, it will provide a more configurable option to use image location in pod configs.
 
## Environment details:

* On Premise Hosted Private Kuberentes Cluster
* Images are uploaded to Private/Hosted Docker Registry   

## Steps to reproduce the issue:

1. Hosted Private Kubernetes provider only allows using Hosted Docker Registry (Like Artifactory).     
2. Current Helm deployment does not allow to use Private Docker registry for Openwhisk Component images. as of today, manual changes required in pod/job yaml files to use private Docker registry host/server. 

# Solution 

## Prerequisite - 
- Upload all images of Openwhisk in private/hosted docker repository server. 

## Changes 

- Define an imagePullSecret
- Use a Value Flag to use imagePullSecrets and image repo config. 
- Create a secret of type kubernetes.io/dockerconfigjson for private/hosted docker registry


