### PR TITLE
nginx version bump & doc updates

### DIFF
--- a/docs/configurationChoices.md
+++ b/docs/configurationChoices.md
@@ -42,7 +42,6 @@ to be greater than 1 for the following components:
 - couchdb
 - kafka
 - kafkaprovider
-- nginx
 - redis
 We are actively working on reducing this list and would welcome PRs to help.
 

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -210,9 +210,8 @@ db:
 # Nginx configurations
 nginx:
   imageName: "nginx"
-  imageTag: "1.13"
+  imageTag: "1.15"
   imagePullPolicy: "IfNotPresent"
-  # NOTE: setting replicaCount > 1 is not tested and may not work
   replicaCount: 1
   restartPolicy: "Always"
   httpPort: 80


### PR DESCRIPTION
Bump nginx from 1.13 to 1.15.

Remove nginx from list of components for which replicaCount>1
is not supported. Stateless component -- running multiple replicas
is expected to just work.