### PR TITLE
configure Jobs with backoffLimit instead of activeDeadlineSeconds

### DIFF
--- a/helm/openwhisk/templates/couchdb-init-job.yaml
+++ b/helm/openwhisk/templates/couchdb-init-job.yaml
@@ -10,7 +10,7 @@ metadata:
     name: {{ .Release.Name }}-init-couchdb
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
 spec:
-  activeDeadlineSeconds: 600
+  backoffLimit: 3
   template:
     metadata:
       name: {{ .Release.Name }}-init-couchdb

--- a/helm/openwhisk/templates/install-packages-job.yaml
+++ b/helm/openwhisk/templates/install-packages-job.yaml
@@ -9,7 +9,7 @@ metadata:
     name: {{ .Release.Name }}-install-packages
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
 spec:
-  activeDeadlineSeconds: 900
+  backoffLimit: 3
   template:
     metadata:
       name: {{ .Release.Name }}-install-packages


### PR DESCRIPTION
We want jobs to run until either they've completed or they have
failed multiple times (and thus we want to give up). Should make
deployment more robust when it takes a very long time for the invoker
to docker pull all the runtime images (the install-packages job will
not start until there is at least one healthy invoker).