### PR TITLE
Adding Node.js v12 to kube deployments

### DIFF
--- a/helm/openwhisk/runtimes.json
+++ b/helm/openwhisk/runtimes.json
@@ -7,7 +7,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "nodejs6action",
-                    "tag": "c173d64"
+                    "tag": "ab224ab"
                 },
                 "deprecated": false,
                 "attached": {
@@ -27,7 +27,7 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-nodejs-v8",
-                    "tag": "c173d64"
+                    "tag": "ab224ab"
                 },
                 "deprecated": false,
                 "attached": {
@@ -41,7 +41,21 @@
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-nodejs-v10",
-                    "tag": "c173d64"
+                    "tag": "ab224ab"
+                },
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
+            },
+            {
+                "kind": "nodejs:12",
+                "default": false,
+                "image": {
+                    "prefix": "openwhisk",
+                    "name": "action-nodejs-v12",
+                    "tag": "ab224ab"
                 },
                 "deprecated": false,
                 "attached": {


### PR DESCRIPTION
Updated runtimes manifest now new runtime images are available.