### PR TITLE
Revert "disable zookeeper readiness probe (#471)"

### DIFF
--- a/helm/openwhisk/templates/zookeeper-pod.yaml
+++ b/helm/openwhisk/templates/zookeeper-pod.yaml
@@ -62,15 +62,14 @@ spec:
             port: {{ .Values.zookeeper.port }}
           initialDelaySeconds: 5
           periodSeconds: 10
-        # Disabled: See issue https://github.com/apache/incubator-openwhisk-deploy-kube/issues/469
-        # readinessProbe:
-        #   exec:
-        #     command:
-        #     - /bin/bash
-        #     - -c
-        #     - "echo ruok | nc -w 1 localhost:{{ .Values.zookeeper.port }} | grep imok"
-        #   initialDelaySeconds: 5
-        #   periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - "echo ruok | nc -w 1 localhost:{{ .Values.zookeeper.port }} | grep imok"
+          initialDelaySeconds: 5
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /conf
           name: zk-config


### PR DESCRIPTION
This reverts commit ab8cd8c600672d10ae80c395fee6eb90a7d320a7.

The PR to the upstream official docker image to restore `nc`
by adding netcat to the apt-get list in the Dockerfile used
to build the official zookeeper image was merged.

Fixes #469 