### PR TITLE
renable zookeeper readiness probe; `nc` restored in upstream image

### DIFF
--- a/helm/openwhisk/templates/zookeeper-pod.yaml
+++ b/helm/openwhisk/templates/zookeeper-pod.yaml
@@ -77,16 +77,15 @@ spec:
           initialDelaySeconds: {{ .Values.probes.zookeeper.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.zookeeper.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.probes.zookeeper.livenessProbe.timeoutSeconds }}
-        # Disabled: See issue https://github.com/apache/incubator-openwhisk-deploy-kube/issues/469
-        # readinessProbe:
-        #   exec:
-        #     command:
-        #     - /bin/bash
-        #     - -c
-        #     - "echo ruok | nc -w 1 localhost:{{ .Values.zookeeper.port }} | grep imok"
-        #   initialDelaySeconds: {{ .Values.probes.zookeeper.readinessProbe.initialDelaySeconds }}
-        #   periodSeconds: {{ .Values.probes.zookeeper.readinessProbe.periodSeconds }}
-        #   timeoutSeconds: {{ .Values.probes.zookeeper.readinessProbe.timeoutSeconds }}
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - "echo ruok | nc -w 1 localhost:{{ .Values.zookeeper.port }} | grep imok"
+            initialDelaySeconds: {{ .Values.probes.zookeeper.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.zookeeper.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.zookeeper.readinessProbe.timeoutSeconds }}
         volumeMounts:
         - mountPath: /conf
           name: zk-config


### PR DESCRIPTION
Fixes #469.
