### PR TITLE
Add configurations for prometheus and metrics

### DIFF
--- a/docs/configurationChoices.md
+++ b/docs/configurationChoices.md
@@ -229,3 +229,32 @@ probes:
 ```
 
 **Note:** currently, probes settings are available for `zookeeper` and `controllers` only.
+
+### Metrics and prometheus support
+
+OpenWhisk distinguishes between system and user metrics. System metrics typically contain information about system performance and use Kamon to collect. User metrics encompass information about action performance which is sent to Kafka in a form of events.
+
+If you want to collect system metrics, store and display them with prometheus, use below configuration in `mycluster.yaml`:
+
+```
+metrics:
+  prometheusEnabled: true
+```
+
+You also need to enable your prometheus to scrape those metrics, add below `scrape_configs` to your prometheus configuration file:
+```
+global:
+  scrape_interval: 1s
+scrape_configs:
+  - job_name: 'kamon-metrics'
+    static_configs:
+      - targets:['<controller_host>:8080','<invoker_host>:8080']
+```
+**Note:** replace `<controller_host>` and `<invoker_host>` with the real host name of controller and invoker.
+
+If you want to enable user metrics, use below configuration in `mycluster.yaml`:
+
+```
+metrics:
+  userMetricsEnabled: true
+```

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -79,6 +79,11 @@ app: {{ template "openwhisk.fullname" . }}
 {{ .Files.Get .Values.whisk.runtimes | quote }}
 {{- end -}}
 
+{{/* Whisk Config */}}
+{{- define "openwhisk.whiskconfig" -}}
+{{ .Files.Get .Values.metrics.whiskconfigFile | b64enc }}
+{{- end -}}
+
 {{/* Environment variables required for accessing CouchDB from a pod */}}
 {{- define "openwhisk.dbEnvVars" -}}
 - name: "CONFIG_whisk_couchdb_username"

--- a/helm/openwhisk/templates/controller-pod.yaml
+++ b/helm/openwhisk/templates/controller-pod.yaml
@@ -154,6 +154,22 @@ spec:
         - name: "CONFIG_akka_discovery_kubernetesApi_podPortName"
           value: "akka-mgmt-http"
 {{- end }}
+{{- if .Values.metrics.prometheusEnabled }}
+        - name: "OPENWHISK_ENCODED_CONFIG"
+          value: {{ template "openwhisk.whiskconfig" . }}
+{{- end }}
+{{ if or .Values.metrics.kamonEnabled .Values.metrics.prometheusEnabled }}
+        - name: "METRICS_KAMON"
+          value: "true"
+{{ end }}
+{{ if or .Values.metrics.kamonTags .Values.metrics.prometheusEnabled }}
+        - name: "METRICS_KAMON_TAGS"
+          value: "true"
+{{ end }}
+{{ if .Values.metrics.userMetricsEnabled }}
+        - name: "CONFIG_whisk_userEvents_enabled"
+          value: "true"
+{{ end }}
         # properties for lean messaging provider
 {{ include "openwhisk.lean.provider" . | indent 8 }}
 

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -169,7 +169,22 @@ spec:
           # properties for zookeeper connection
           - name: "ZOOKEEPER_HOSTS"
             value: "{{ include "openwhisk.zookeeper_connect" . }}"
-
+{{ if .Values.metrics.prometheusEnabled }}
+          - name: "OPENWHISK_ENCODED_CONFIG"
+            value: {{ template "openwhisk.whiskconfig" . }}
+{{ end }}
+{{ if or .Values.metrics.kamonEnabled .Values.metrics.prometheusEnabled }}
+          - name: "METRICS_KAMON"
+            value: "true"
+{{ end }}
+{{ if and .Values.metrics.kamonTags .Values.metrics.prometheusEnabled }}
+          - name: "METRICS_KAMON_TAGS"
+            value: "true"
+{{ end }}
+{{ if .Values.metrics.userMetricsEnabled }}
+          - name: "CONFIG_whisk_userEvents_enabled"
+            value: "true"
+{{ end }}
         ports:
         - name: invoker
           containerPort: {{ .Values.invoker.port }}

--- a/helm/openwhisk/values-metadata.yaml
+++ b/helm/openwhisk/values-metadata.yaml
@@ -1525,3 +1525,39 @@ probes:
       type: "number"
       required: false
 
+# Metrics
+metrics:
+  __metadata:
+    label: "Metrics configuration"
+    description: "configurations to enable and configure Kamon metrics from controller and invoker."
+  prometheusEnabled:
+    __metadata:
+      label: "enable Prometheus support"
+      description: "true to enable kamon-prometheus exporter, metrics would be exposed at `/metrics` endpoint"
+      type: "boolean"
+      required: true
+  whiskconfigFile:
+    __metadata:
+      label: "whiskconfig file name"
+      description: "file name of whiskconfig"
+      type: "string"
+      required: false
+  kamonEnabled:
+    __metadata:
+      label: "enable kamon metrics collection"
+      description: "whether metric information is sent to the configured reporters"
+      type: "boolean"
+      required: true
+  kamonTags:
+    __metadata:
+      label: "enable kamon tag"
+      description: "whether to use the Kamon tags when sending metrics"
+      type: "boolean"
+      required: true
+  userMetricsEnabled:
+    __metadata:
+      label: "enable user metrics"
+      description: "true to enable user metrics"
+      type: "boolean"
+      required: true
+

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -300,6 +300,19 @@ redis:
   persistence:
     size: 256Mi
 
+# Metrics
+metrics:
+  # set true to enable prometheus exporter
+  prometheusEnabled: false
+  # passing prometheus-enabled by a config file, required by openwhisk
+  whiskconfigFile: "whiskconfig.conf"
+  # set true to enable Kamon
+  kamonEnabled: false
+  # set true to enable Kamon tags
+  kamonTags: false
+  # set true to enable user metrics
+  userMetricsEnabled: false
+
 # Configuration of OpenWhisk event providers
 providers:
   # CouchDB instance used by all enabled providers to store event/configuration data.

--- a/helm/openwhisk/whiskconfig.conf
+++ b/helm/openwhisk/whiskconfig.conf
@@ -1,0 +1,10 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+include classpath("application.conf")
+
+whisk {
+  metrics {
+    prometheus-enabled = true
+  }
+}


### PR DESCRIPTION
This PR is to add configurations for prometheus and metrics supporting.

After adding below configurations, controller and invoker are exposing `/metrics` endpoints on container port `8080`.
```
metrics:
  prometheusEnabled: true
  whiskconfigFile: "whiskconfig.conf"
  kamonEnabled: true
  kamonTags: true
```