### PR TITLE
feat: add k8s tolerations support

### DIFF
--- a/helm/openwhisk/templates/_tolerations.tpl
+++ b/helm/openwhisk/templates/_tolerations.tpl
@@ -1,0 +1,23 @@
+{{/* Core toleration */}}
+{{- define "openwhisk.toleration.core" -}}
+- key: "openwhisk-role"
+  operator: "Equal"
+  value: {{ .Values.toleration.coreValue }}
+  effect: "NoSchedule"
+{{- end -}}
+
+ {{/* Edge toleration */}}
+{{- define "openwhisk.toleration.edge" -}}
+- key: "openwhisk-role"
+  operator: "Equal"
+  value: {{ .Values.toleration.edgeValue }}
+  effect: "NoSchedule"
+{{- end -}}
+
+ {{/* Invoker toleration */}}
+{{- define "openwhisk.toleration.invoker" -}}
+- key: "openwhisk-role"
+  operator: "Equal"
+  value: {{ .Values.toleration.invokerValue }}
+  effect: "NoSchedule"
+{{- end -}}

--- a/helm/openwhisk/templates/apigateway-pod.yaml
+++ b/helm/openwhisk/templates/apigateway-pod.yaml
@@ -40,6 +40,12 @@ spec:
 {{ include "openwhisk.affinity.core" . | indent 8 }}
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-apigateway" .Release.Name ) | indent 8 }}
       {{- end }}
+
+      {{- if .Values.toleration.enabled }}
+      tolerations:
+{{ include "openwhisk.toleration.core" . | indent 8 }}
+      {{- end }}
+
 {{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
         - name: apigateway

--- a/helm/openwhisk/templates/controller-pod.yaml
+++ b/helm/openwhisk/templates/controller-pod.yaml
@@ -44,6 +44,11 @@ spec:
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-controller" .Release.Name ) | indent 8 }}
       {{- end }}
 
+      {{- if .Values.toleration.enabled }}
+      tolerations:
+{{ include "openwhisk.toleration.core" . | indent 8 }}
+      {{- end }}
+
       initContainers:
 {{- if not .Values.controller.lean }}
       # The controller must wait for kafka and/or couchdb to be ready before it starts

--- a/helm/openwhisk/templates/couchdb-pod.yaml
+++ b/helm/openwhisk/templates/couchdb-pod.yaml
@@ -41,6 +41,12 @@ spec:
 {{ include "openwhisk.affinity.core" . | indent 8 }}
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-couchdb" .Release.Name ) | indent 8 }}
       {{- end }}
+
+      {{- if .Values.toleration.enabled }}
+      tolerations:
+{{ include "openwhisk.toleration.core" . | indent 8 }}
+      {{- end }}
+
 {{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
       containers:
       - name: couchdb

--- a/helm/openwhisk/templates/invoker-agent-pod.yaml
+++ b/helm/openwhisk/templates/invoker-agent-pod.yaml
@@ -39,6 +39,11 @@ spec:
       affinity:
 {{ include "openwhisk.affinity.invoker" . | indent 8 }}
 
+{{- if .Values.toleration.enabled }}
+      tolerations:
+{{ include "openwhisk.toleration.invoker" . | indent 8 }}
+{{- end }}
+
       volumes:
 {{ include "openwhisk.docker_volumes" . | indent 6 }}
       - name: userlogs

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -55,6 +55,11 @@ spec:
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-invoker" .Release.Name ) | indent 8 }}
 {{- end }}
 
+{{- if .Values.toleration.enabled }}
+      tolerations:
+{{ include "openwhisk.toleration.invoker" . | indent 8 }}
+{{- end }}
+
 {{ include "openwhisk.invoker.volumes" . }}
 
       initContainers:

--- a/helm/openwhisk/templates/kafka-pod.yaml
+++ b/helm/openwhisk/templates/kafka-pod.yaml
@@ -45,6 +45,11 @@ spec:
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-kafka" .Release.Name ) | indent 8 }}
       {{- end }}
 
+      {{- if .Values.toleration.enabled }}
+      tolerations:
+{{ include "openwhisk.toleration.core" . | indent 8 }}
+      {{- end }}
+
 {{- if and .Values.k8s.persistence.enabled (eq (int .Values.kafka.replicaCount) 1) }}
       volumes:
       - name: "{{ .Release.Name }}-kafka-pvc"

--- a/helm/openwhisk/templates/nginx-pod.yaml
+++ b/helm/openwhisk/templates/nginx-pod.yaml
@@ -41,6 +41,11 @@ spec:
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-nginx" .Release.Name ) | indent 8 }}
       {{- end }}
 
+      {{- if .Values.toleration.enabled }}
+      tolerations:
+{{ include "openwhisk.toleration.edge" . | indent 8 }}
+      {{- end }}
+
       volumes:
       - name: nginx-certs
         secret:

--- a/helm/openwhisk/templates/redis-pod.yaml
+++ b/helm/openwhisk/templates/redis-pod.yaml
@@ -41,6 +41,11 @@ spec:
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-redis" .Release.Name | quote ) | indent 8 }}
       {{- end }}
 
+      {{- if .Values.toleration.enabled }}
+      tolerations:
+{{ include "openwhisk.toleration.core" . | indent 8 }}
+      {{- end }}
+
 {{- if .Values.k8s.persistence.enabled }}
       volumes:
       - name: redis-data

--- a/helm/openwhisk/templates/zookeeper-pod.yaml
+++ b/helm/openwhisk/templates/zookeeper-pod.yaml
@@ -45,6 +45,11 @@ spec:
 {{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-zookeeper" .Release.Name ) | indent 8 }}
 {{- end }}
 
+{{- if .Values.toleration.enabled }}
+      tolerations:
+{{ include "openwhisk.toleration.core" . | indent 8 }}
+{{- end }}
+
       volumes:
         - name: zk-config
           configMap:

--- a/helm/openwhisk/values-metadata.yaml
+++ b/helm/openwhisk/values-metadata.yaml
@@ -1498,6 +1498,35 @@ affinity:
       type: "string"
       required: true
 
+toleration:
+  __metadata:
+    label: "Node toleration configuration"
+    description: "Key used for node tolerations"
+  enabled:
+    __metadata:
+      label: "Toleration enabled"
+      description: "If toleration should be enabled"
+      type: "boolean"
+      required: true
+  coreValue:
+    __metadata:
+      label: "Core openwhisk-role toleration value"
+      description: "Value used for worker nodes toleration that should execute OpenWhisk core pods"
+      type: "string"
+      required: true
+  edgeValue:
+    __metadata:
+      label: "Edge openwhisk-role toleration value"
+      description: "Value used for worker nodes toleration that should execute OpenWhisk edge pods"
+      type: "string"
+      required: true
+  invokerValue:
+    __metadata:
+      label: "Invoker openwhisk-role toleration value"
+      description: "Value used for worker nodes toleration that should execute OpenWhisk invoker pods"
+      type: "string"
+      required: true
+
 probes:
   _metadata:
   label: "Pod's liveness and readiness time related settings"

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -374,6 +374,15 @@ affinity:
   invokerNodeLabel: invoker
   providerNodeLabel: provider
 
+# Used to define toleration for the Kubernetes scheduler.
+# If tolerations.enabled is true, then all of the deployments for the OpenWhisk
+# microservices will add tolerations for key openwhisk-role with specified value and effect NoSchedule.
+toleration:
+  enabled: true
+  coreValue: core
+  edgeValue: edge
+  invokerValue: invoker
+
 # Used to define the probes timing settings so that you can more precisely control the
 # liveness and readiness checks.
 # initialDelaySeconds - Initial wait time to start probes after container has started


### PR DESCRIPTION
Tolerations are pretty much a must when using separate node pools with taint for openwhisk.