### PR TITLE
Configure same affinity policies as array

### DIFF
--- a/helm/openwhisk/templates/_affinity.tpl
+++ b/helm/openwhisk/templates/_affinity.tpl
@@ -29,9 +29,6 @@ nodeAffinity:
         operator: NotIn
         values:
         - {{ .Values.affinity.invokerNodeLabel }}
-# prefer to run on a core node
-nodeAffinity:
-  preferredDuringSchedulingIgnoredDuringExecution:
   - weight: 80
     preference:
       matchExpressions:
@@ -54,9 +51,6 @@ nodeAffinity:
         operator: NotIn
         values:
         - {{ .Values.affinity.invokerNodeLabel }}
-# prefer to run on a edge node
-nodeAffinity:
-  preferredDuringSchedulingIgnoredDuringExecution:
   - weight: 80
     preference:
       matchExpressions:
@@ -79,8 +73,6 @@ nodeAffinity:
         operator: NotIn
         values:
         - {{ .Values.affinity.invokerNodeLabel }}
-# prefer to run on a provider node
-nodeAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
   - weight: 80
     preference:


### PR DESCRIPTION
Currently affinity value are getting duplicated and override the values. For example rendering the controller-pod.yaml

```
helm template  openwhisk --name whisk -x templates/controller-pod.yaml  --output-dir ../build
```

Renders the yaml with following content

```yaml
      serviceAccountName: whisk-core
      restartPolicy: Always
      affinity:
        # prefer to not run on an invoker node (only prefer because of single node clusters)
        nodeAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 100
            preference:
              matchExpressions:
              - key: openwhisk-role
                operator: NotIn
                values:
                - invoker
        # prefer to run on a core node
        nodeAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 80
            preference:
              matchExpressions:
              - key: openwhisk-role
                operator: In
                values:
                - core
        # Fault tolerance: prevent multiple instances of bladerunner-controller from running on the same node
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: name
                operator: In
                values:
                - whisk-controller
            topologyKey: "kubernetes.io/hostname"

      initContainers:
```

As can be seen that under `affinity` there are 2 entries for `nodeAffinity` which would result in last one overwriting the first one. 

Ideally this should be flagged in `helm lint` however it looks like this check is missing per helm/helm#5524